### PR TITLE
Broadcast: Neon-autosuspend caching + devtools monitoring + form copy touch-ups (login-independent slice of broadcast-touchup)

### DIFF
--- a/backendServer/backend/settings/base.py
+++ b/backendServer/backend/settings/base.py
@@ -168,6 +168,11 @@ CACHES = {
     }
 }
 
+# Sessions (admin-only) live in the Redis cache (DB 1), not the Neon django_session
+# table, so idle Django holds no DB-backed session traffic — trade-off: a Redis
+# flush logs admins out, which is acceptable since sessions here are admin-only.
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+
 BETTER_AUTH_JWKS_URL = os.environ.get("BETTER_AUTH_JWKS_URL", "")
 BETTER_AUTH_ISSUER = os.environ.get("BETTER_AUTH_ISSUER", "")
 BETTER_AUTH_AUDIENCE = os.environ.get("BETTER_AUTH_AUDIENCE", "")

--- a/backendServer/backend/settings/prod.py
+++ b/backendServer/backend/settings/prod.py
@@ -25,5 +25,8 @@ DATABASES = {
         "HOST": _db.hostname,
         "PORT": 5432,
         "OPTIONS": dict(parse_qsl(_db.query)),
+        # Deliberately not pooling: 0 means Django closes the connection after each
+        # request, so idle Django holds no open connection and Neon compute can autosuspend.
+        "CONN_MAX_AGE": 0,
     }
 }

--- a/backendServer/broadcast/access.py
+++ b/backendServer/broadcast/access.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from django.utils import timezone
 
 from backend.jwt_auth import verify_better_auth_jwt
+from broadcast import cache as access_cache
 from broadcast.models import AccessCode, AccessCodeRedemption, BroadcastAccess
 
 # ---------------------------------------------------------------------------
@@ -71,17 +72,21 @@ def resolve_access(request, draft_id: str | None = None) -> AccessResult:  # noq
     if auth_header.startswith("Bearer "):
         email = authenticated_email(request)
         if email:
-            try:
-                grant = BroadcastAccess.objects.get(email=email)
-                tier = grant.tier
-            except BroadcastAccess.DoesNotExist:
-                tier = 0
+            cached = access_cache.get_jwt_access(email)
+            if cached is None:
+                try:
+                    grant = BroadcastAccess.objects.get(email=email)
+                    tier = grant.tier
+                except BroadcastAccess.DoesNotExist:
+                    tier = 0
+                cached = {"tier": tier, "identity": email, "client_label": email}
+                access_cache.set_jwt_access(email, cached)
             return AccessResult(
-                tier=tier,
-                identity=email,
+                tier=cached["tier"],
+                identity=cached["identity"],
                 is_trial=False,
                 uses_remaining=None,
-                client_label=email,
+                client_label=cached["client_label"],
                 code=None,
             )
         # JWT present (valid or invalid) but unusable → no access, skip code path
@@ -100,10 +105,29 @@ def resolve_access(request, draft_id: str | None = None) -> AccessResult:  # noq
         incoming_hash = hash_code(raw_code)
         now = timezone.now()
 
+        cached_meta = access_cache.get_code_meta(incoming_hash)
         matched = None
-        for code in AccessCode.objects.filter(is_active=True, kind=AccessCode.KIND_TRIAL):
-            if hmac.compare_digest(code.code_hash, incoming_hash):
-                matched = code
+        if cached_meta is None:
+            for code in AccessCode.objects.filter(is_active=True, kind=AccessCode.KIND_TRIAL):
+                if hmac.compare_digest(code.code_hash, incoming_hash):
+                    matched = code
+            if matched is not None:
+                access_cache.set_code_meta(
+                    incoming_hash,
+                    {
+                        "code_id": matched.id,
+                        "tier": matched.tier,
+                        "label": matched.label,
+                        "max_uses": matched.max_uses,
+                        "expires_at": matched.expires_at.isoformat()
+                        if matched.expires_at is not None
+                        else None,
+                    },
+                )
+        else:
+            # Identity is cached, but uses()/max_uses enforcement must always be
+            # live — fetch the row to run the same count/expiry checks as a miss.
+            matched = AccessCode.objects.filter(id=cached_meta["code_id"]).first()
 
         if matched is not None:
             if matched.expires_at is not None and matched.expires_at < now:
@@ -168,4 +192,5 @@ def redeem_upgrade_code(email: str, raw_code: str) -> int | None:
 
     BroadcastAccess.objects.update_or_create(email=email, defaults={"tier": matched.tier})
     AccessCodeRedemption.objects.get_or_create(access_code=matched, email=email)
+    access_cache.invalidate_jwt_access(email)
     return matched.tier

--- a/backendServer/broadcast/apps.py
+++ b/backendServer/broadcast/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class BroadcastConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "broadcast"
+
+    def ready(self):
+        from . import signals  # noqa: F401  — registers cache-invalidation receivers

--- a/backendServer/broadcast/cache.py
+++ b/backendServer/broadcast/cache.py
@@ -1,0 +1,74 @@
+"""Read-through cache for broadcast access resolution.
+
+resolve_access() runs on every authed broadcast API request via
+_BroadcastTierPermission, so a naive implementation fires a Neon read per
+request (worst case: a client polling a running job every few seconds). This
+module caches the two identity lookups resolve_access() makes — the JWT
+path's BroadcastAccess grant, and the trial-code path's matched AccessCode —
+so repeat resolutions within ACCESS_TTL don't hit the DB.
+
+Consumption counts (AccessCodeUse.count(), max_uses enforcement) are
+deliberately NOT cached here — resolve_access() always re-checks those live
+so caching never weakens the max_uses guard.
+
+27.5 added the job-status helpers below: job_detail() polls (broadcastWeb hits
+GET /broadcast/jobs/{id} every 3s while a job runs) are served straight from
+Redis instead of re-querying BroadcastSubmission + its targets on every poll.
+Every status transition in services.py/worker.py/runner.py writes the fresh
+payload through to this cache, so job_detail() only touches Neon on a cold
+cache (first read after a restart/eviction).
+"""
+
+from django.core.cache import cache
+
+ACCESS_TTL = 300  # seconds
+JOB_TTL = 60 * 60  # seconds — comfortably longer than any job's lifetime, so
+# terminal-state polls (done/failed/canceled) keep hitting cache, not Neon.
+
+
+def _jwt_key(email: str) -> str:
+    return f"broadcast:access:jwt:{email}"
+
+
+def get_jwt_access(email: str) -> dict | None:
+    return cache.get(_jwt_key(email))
+
+
+def set_jwt_access(email: str, data: dict) -> None:
+    cache.set(_jwt_key(email), data, ACCESS_TTL)
+
+
+def invalidate_jwt_access(email: str) -> None:
+    cache.delete(_jwt_key(email))
+
+
+def _code_key(code_hash: str) -> str:
+    return f"broadcast:access:code:{code_hash}"
+
+
+def get_code_meta(code_hash: str) -> dict | None:
+    return cache.get(_code_key(code_hash))
+
+
+def set_code_meta(code_hash: str, data: dict) -> None:
+    cache.set(_code_key(code_hash), data, ACCESS_TTL)
+
+
+def invalidate_code_meta(code_hash: str) -> None:
+    cache.delete(_code_key(code_hash))
+
+
+def _job_key(job_id) -> str:
+    return f"broadcast:job:{job_id}"
+
+
+def get_job_payload(job_id) -> dict | None:
+    return cache.get(_job_key(job_id))
+
+
+def set_job_payload(job_id, payload: dict) -> None:
+    cache.set(_job_key(job_id), payload, JOB_TTL)
+
+
+def invalidate_job(job_id) -> None:
+    cache.delete(_job_key(job_id))

--- a/backendServer/broadcast/runner.py
+++ b/backendServer/broadcast/runner.py
@@ -21,6 +21,7 @@ from broadcast.adapters import get_adapter
 from broadcast.adapters.base import RunContext, TargetResult
 from broadcast.models import BroadcastSubmission
 from broadcast.schema import event_from_submission
+from broadcast.services import refresh_job_cache
 
 logger = logging.getLogger("broadcast")
 
@@ -33,6 +34,7 @@ def run_submission(submission: BroadcastSubmission) -> None:
     submission.status = "running"  # idempotent if the worker already claimed it
     submission.started_at = timezone.now()
     submission.save(update_fields=["status", "started_at"])
+    refresh_job_cache(submission)
 
     ev = event_from_submission(submission)
     targets = list(submission.targets.filter(status="pending").order_by("site_key"))
@@ -48,6 +50,7 @@ def run_submission(submission: BroadcastSubmission) -> None:
         target.attempts += 1
         target.started_at = timezone.now()
         target.save(update_fields=["status", "attempts", "started_at"])
+        refresh_job_cache(submission)
 
         result = _run_target(target, ev)
 
@@ -65,6 +68,7 @@ def run_submission(submission: BroadcastSubmission) -> None:
                 "finished_at",
             ]
         )
+        refresh_job_cache(submission)
         if result.status == "failed":
             any_failed = True
         logger.info("broadcast %s → %s: %s", submission.id, target.site_key, result.status)
@@ -75,11 +79,13 @@ def run_submission(submission: BroadcastSubmission) -> None:
         submission.targets.filter(status="pending").update(status="skipped")
         submission.finished_at = timezone.now()
         submission.save(update_fields=["finished_at"])
+        refresh_job_cache(submission)
         return
 
     submission.status = "failed" if any_failed else "done"
     submission.finished_at = timezone.now()
     submission.save(update_fields=["status", "finished_at"])
+    refresh_job_cache(submission)
 
 
 def _run_target(target, ev) -> TargetResult:

--- a/backendServer/broadcast/services.py
+++ b/backendServer/broadcast/services.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from django.db import transaction
 from django.utils import timezone
 
+from broadcast import cache as broadcast_cache
 from broadcast.models import BroadcastSubmission, BroadcastTarget
 from broadcast.schema import CanonicalEvent, event_from_submission
 
@@ -52,6 +53,7 @@ def create_submission(
     for site_key in dict.fromkeys(site_keys):
         BroadcastTarget.objects.create(submission=submission, site_key=site_key, dry_run=dry_run)
     _dispatch_worker()
+    refresh_job_cache(submission)
     return submission
 
 
@@ -72,6 +74,7 @@ def retry_targets(submission: BroadcastSubmission, site_keys: list[str]) -> int:
         submission.finished_at = None
         submission.save(update_fields=["status", "finished_at"])
         _dispatch_worker()
+        refresh_job_cache(submission)
     return updated
 
 
@@ -94,6 +97,7 @@ def force_retry_stuck_target(submission: BroadcastSubmission, site_keys: list[st
         submission.finished_at = None
         submission.save(update_fields=["status", "finished_at"])
         _dispatch_worker()
+        refresh_job_cache(submission)
     return updated
 
 
@@ -115,6 +119,7 @@ def submit_real_targets(submission: BroadcastSubmission, site_keys: list[str]) -
         submission.finished_at = None
         submission.save(update_fields=["status", "finished_at"])
         _dispatch_worker()
+        refresh_job_cache(submission)
     return updated
 
 
@@ -132,6 +137,7 @@ def cancel_submission(submission: BroadcastSubmission) -> int:
     submission.status = "canceled"
     submission.finished_at = timezone.now()
     submission.save(update_fields=["status", "finished_at"])
+    refresh_job_cache(submission)
     return skipped
 
 
@@ -174,3 +180,11 @@ def job_payload(submission: BroadcastSubmission) -> dict:
         "finished_at": submission.finished_at.isoformat() if submission.finished_at else None,
         "targets": targets,
     }
+
+
+def refresh_job_cache(submission: BroadcastSubmission) -> None:
+    """Write the current job_payload through to Redis so job_detail() polls
+    (every 3s while broadcastWeb watches a running job) are served from cache
+    instead of re-hitting Neon. Call this immediately after every status
+    transition — see cache.py's module docstring for the full call-site list."""
+    broadcast_cache.set_job_payload(str(submission.id), job_payload(submission))

--- a/backendServer/broadcast/signals.py
+++ b/backendServer/broadcast/signals.py
@@ -1,0 +1,24 @@
+"""Cache invalidation on writes to the cached access models.
+
+Registered in BroadcastConfig.ready(). BroadcastAccess writes clear that
+email's JWT-path cache entry; AccessCode writes clear that code's
+trial-path meta entry.
+"""
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from . import cache as access_cache
+from .models import AccessCode, BroadcastAccess
+
+
+@receiver(post_save, sender=BroadcastAccess)
+@receiver(post_delete, sender=BroadcastAccess)
+def invalidate_broadcast_access(sender, instance, **kwargs):
+    access_cache.invalidate_jwt_access(instance.email)
+
+
+@receiver(post_save, sender=AccessCode)
+@receiver(post_delete, sender=AccessCode)
+def invalidate_access_code(sender, instance, **kwargs):
+    access_cache.invalidate_code_meta(instance.code_hash)

--- a/backendServer/broadcast/tests/test_access_cache.py
+++ b/backendServer/broadcast/tests/test_access_cache.py
@@ -1,0 +1,179 @@
+"""DB-tier tests for the broadcast.cache read-through layer around resolve_access.
+
+Uses @tag("db") + TestCase (real Postgres test DB). Test settings swap CACHES to
+LocMemCache, so no Redis is needed here. JWT path stubs verify_better_auth_jwt via
+unittest.mock.patch — no JWKS hit.
+"""
+
+from unittest import mock
+
+from django.core.cache import cache as django_cache
+from django.test import RequestFactory, TestCase, tag
+
+from broadcast.access import hash_code, redeem_upgrade_code, resolve_access
+from broadcast.models import AccessCode, AccessCodeUse, BroadcastAccess
+
+
+def _make_request(*, auth_header: str | None = None, code_header: str | None = None):
+    factory = RequestFactory()
+    headers = {}
+    if auth_header:
+        headers["HTTP_AUTHORIZATION"] = auth_header
+    if code_header:
+        headers["HTTP_X_BROADCAST_ACCESS_CODE"] = code_header
+    req = factory.post("/", **headers)  # type: ignore[arg-type]
+    req.data = {}  # type: ignore[attr-defined]
+    return req
+
+
+def _make_code(
+    label="testclient",
+    tier=2,
+    max_uses=3,
+    is_active=True,
+    raw="RAWCODE",
+    kind=AccessCode.KIND_TRIAL,
+):
+    return AccessCode.objects.create(
+        code_hash=hash_code(raw),
+        label=label,
+        kind=kind,
+        tier=tier,
+        max_uses=max_uses,
+        is_active=is_active,
+    )
+
+
+def _patch_jwt(claims):
+    return mock.patch("broadcast.access.verify_better_auth_jwt", return_value=claims)
+
+
+@tag("db")
+class JWTPathCacheTest(TestCase):
+    def setUp(self):
+        django_cache.clear()
+
+    def test_second_resolution_within_ttl_skips_db_lookup(self):
+        BroadcastAccess.objects.create(email="alice@example.com", tier=2)
+        req1 = _make_request(auth_header="Bearer faketoken")
+        req2 = _make_request(auth_header="Bearer faketoken")
+
+        with _patch_jwt({"email": "alice@example.com"}):
+            first = resolve_access(req1)
+            # Only the first resolution should touch broadcast_broadcastaccess —
+            # the second must be served entirely from cache.
+            with self.assertNumQueries(0):
+                second = resolve_access(req2)
+
+        self.assertEqual(first.tier, 2)
+        self.assertEqual(second.tier, 2)
+        self.assertEqual(second.identity, "alice@example.com")
+
+    def test_no_grant_row_is_also_cached(self):
+        req1 = _make_request(auth_header="Bearer faketoken")
+        req2 = _make_request(auth_header="Bearer faketoken")
+
+        with _patch_jwt({"email": "nobody@example.com"}):
+            first = resolve_access(req1)
+            with self.assertNumQueries(0):
+                second = resolve_access(req2)
+
+        self.assertEqual(first.tier, 0)
+        self.assertEqual(second.tier, 0)
+
+    def test_redeeming_upgrade_code_invalidates_cache(self):
+        BroadcastAccess.objects.create(email="alice@example.com", tier=0)
+        req = _make_request(auth_header="Bearer faketoken")
+
+        with _patch_jwt({"email": "alice@example.com"}):
+            stale = resolve_access(req)
+        self.assertEqual(stale.tier, 0)
+
+        upgrade_code = AccessCode.objects.create(
+            code_hash=hash_code("UPGRADERAW"),
+            label="acme",
+            kind=AccessCode.KIND_UPGRADE,
+            tier=2,
+            max_uses=None,
+        )
+        redeem_upgrade_code("alice@example.com", "UPGRADERAW")
+
+        req2 = _make_request(auth_header="Bearer faketoken")
+        with _patch_jwt({"email": "alice@example.com"}):
+            fresh = resolve_access(req2)
+        self.assertEqual(fresh.tier, 2)
+        self.assertEqual(upgrade_code.tier, 2)
+
+    def test_post_save_on_broadcast_access_invalidates_cache(self):
+        grant = BroadcastAccess.objects.create(email="bob@example.com", tier=1)
+        req = _make_request(auth_header="Bearer faketoken")
+        with _patch_jwt({"email": "bob@example.com"}):
+            stale = resolve_access(req)
+        self.assertEqual(stale.tier, 1)
+
+        grant.tier = 2
+        grant.save()
+
+        req2 = _make_request(auth_header="Bearer faketoken")
+        with _patch_jwt({"email": "bob@example.com"}):
+            fresh = resolve_access(req2)
+        self.assertEqual(fresh.tier, 2)
+
+
+@tag("db")
+class CodePathCacheTest(TestCase):
+    def setUp(self):
+        django_cache.clear()
+
+    def test_second_resolution_within_ttl_skips_code_scan(self):
+        _make_code(raw="MYCODE", max_uses=5)
+        req1 = _make_request(code_header="MYCODE")
+        req2 = _make_request(code_header="MYCODE")
+
+        first = resolve_access(req1)
+        self.assertEqual(first.tier, 2)
+        self.assertEqual(first.uses_remaining, 5)
+
+        with self.assertNumQueries(2):
+            # 1 query to fetch the AccessCode row by cached id, 1 to count uses —
+            # no scan over AccessCode.objects.filter(is_active=True, kind=TRIAL).
+            second = resolve_access(req2)
+        self.assertEqual(second.tier, 2)
+        self.assertEqual(second.uses_remaining, 5)
+
+    def test_near_exhausted_code_still_denied_on_cache_hit(self):
+        """Caching the code's identity must never weaken max_uses enforcement:
+        uses().count() and the over-use guard must still run live on a cache hit."""
+        code = _make_code(raw="EXCODE", max_uses=2)
+        req_warm = _make_request(code_header="EXCODE")
+        warm = resolve_access(req_warm, draft_id="draft-1")
+        self.assertEqual(warm.tier, 2)
+
+        # Consume both slots after the identity is already cached.
+        AccessCodeUse.objects.create(access_code=code, draft_id="draft-1")
+        AccessCodeUse.objects.create(access_code=code, draft_id="draft-2")
+
+        req_new = _make_request(code_header="EXCODE")
+        denied = resolve_access(req_new, draft_id="draft-3")
+        self.assertEqual(denied.tier, 0)
+        self.assertIsNone(denied.code)
+
+        # An already-counted draft is still allowed through, exactly as the
+        # uncached path behaves.
+        req_counted = _make_request(code_header="EXCODE")
+        allowed = resolve_access(req_counted, draft_id="draft-1")
+        self.assertEqual(allowed.tier, 2)
+        self.assertEqual(allowed.uses_remaining, 0)
+
+    def test_code_deactivation_invalidates_cache(self):
+        code = _make_code(raw="DEACTCODE", max_uses=None)
+        req1 = _make_request(code_header="DEACTCODE")
+        warm = resolve_access(req1)
+        self.assertEqual(warm.tier, 2)
+
+        code.is_active = False
+        code.save()
+
+        req2 = _make_request(code_header="DEACTCODE")
+        result = resolve_access(req2)
+        self.assertEqual(result.tier, 0)

--- a/backendServer/broadcast/tests/test_access_db.py
+++ b/backendServer/broadcast/tests/test_access_db.py
@@ -520,3 +520,39 @@ class RedeemEndpointTest(TestCase):
                 HTTP_AUTHORIZATION="Bearer faketoken",
             )
         self.assertEqual(resp.status_code, 403)
+
+    def test_upgrade_tier2_redemption_survives_reload_via_jwt_path(self):
+        """Regression for 26.2: redeeming a real --kind upgrade --tier 2 code must
+        permanently set BroadcastAccess.tier, and a *later, separate* request on the
+        JWT path (GET /broadcast/access, simulating a page reload) must read that same
+        tier back — including when the email claim's casing differs between the two
+        requests (write path lowercases via request.broadcast_email /
+        authenticated_email; read path must do the same on the JWT claim)."""
+        _make_upgrade_code(raw="RELOADRAW", tier=2)
+
+        # Step 1: logged-in user redeems the upgrade code (JWT claim uppercase).
+        with _patch_jwt({"email": "UPPER@Example.com"}):
+            redeem_resp = self.client.post(
+                "/broadcast/redeem",
+                {"access_code": "RELOADRAW"},
+                format="json",
+                HTTP_AUTHORIZATION="Bearer faketoken",
+            )
+        self.assertEqual(redeem_resp.status_code, 200)
+        self.assertEqual(redeem_resp.json()["tier"], 2)
+
+        # BroadcastAccess row is permanent, keyed by lowercased email.
+        grant = BroadcastAccess.objects.get(email="upper@example.com")
+        self.assertEqual(grant.tier, 2)
+
+        # Step 2: a brand new request (simulating reload) hits the JWT read path with
+        # a differently-cased email claim — must still resolve to tier 2, not tier 0.
+        with _patch_jwt({"email": "Upper@EXAMPLE.com"}):
+            reload_resp = self.client.get(
+                "/broadcast/access",
+                HTTP_AUTHORIZATION="Bearer faketoken",
+            )
+        self.assertEqual(reload_resp.status_code, 200)
+        body = reload_resp.json()
+        self.assertEqual(body["tier"], 2)
+        self.assertFalse(body["is_trial"])

--- a/backendServer/broadcast/tests/test_api.py
+++ b/backendServer/broadcast/tests/test_api.py
@@ -242,6 +242,7 @@ class RetryStuckJobTest(TestCase):
         target.save()
         submission.status = "running"
         submission.save()
+        cache.clear()  # bypass write-through: this test mutates status directly on the row
 
         resp = self._retry_stuck(job_id, ["explore_pittsboro"])
         self.assertEqual(resp.status_code, 200)

--- a/backendServer/broadcast/tests/test_job_cache.py
+++ b/backendServer/broadcast/tests/test_job_cache.py
@@ -1,0 +1,241 @@
+"""DB-tier tests for the broadcast.cache job-status read-through layer (27.5).
+
+broadcastWeb polls GET /broadcast/jobs/{id} every 3s while a job runs; a warm
+cache must serve that poll without touching Neon. Uses @tag("db") + TestCase
+(real Postgres test DB). Test settings swap CACHES to LocMemCache, so no
+Redis is needed here.
+"""
+
+from datetime import UTC, datetime
+from unittest import mock
+
+from django.core.cache import cache as django_cache
+from django.test import TestCase, override_settings, tag
+from rest_framework.test import APIClient
+
+from broadcast import cache as broadcast_cache
+from broadcast.access import hash_code
+from broadcast.models import AccessCode, BroadcastAccess, BroadcastSubmission, BroadcastTarget
+from broadcast.schema import CanonicalEvent
+from broadcast.services import (
+    cancel_submission,
+    create_submission,
+    job_payload,
+    refresh_job_cache,
+    retry_targets,
+)
+
+
+def make_submission(status="queued", site_keys=("a_site",)):
+    submission = BroadcastSubmission.objects.create(
+        client_label="test",
+        title="T",
+        description="D",
+        start_datetime=datetime(2026, 7, 10, 19, 0, tzinfo=UTC),
+        venue_name="V",
+        address_line1="1 Main St",
+        city="Pittsboro",
+        zip="27312",
+        locality=["pittsboro"],
+        categories=["music"],
+        status=status,
+    )
+    for key in site_keys:
+        BroadcastTarget.objects.create(submission=submission, site_key=key)
+    return submission
+
+
+def _patch_jwt(email):
+    return mock.patch("broadcast.access.verify_better_auth_jwt", return_value={"email": email})
+
+
+def _make_code(label="makrs", tier=2, max_uses=None, raw="SECRET1"):
+    return AccessCode.objects.create(
+        code_hash=hash_code(raw),
+        label=label,
+        tier=tier,
+        max_uses=max_uses,
+    )
+
+
+@tag("db")
+class RefreshJobCacheTests(TestCase):
+    """refresh_job_cache() writes a payload that matches job_payload() and
+    stays correct across status transitions."""
+
+    def setUp(self):
+        django_cache.clear()
+
+    def test_refresh_writes_payload_matching_job_payload(self):
+        submission = make_submission(status="queued")
+        refresh_job_cache(submission)
+
+        cached = broadcast_cache.get_job_payload(str(submission.id))
+        self.assertEqual(cached, job_payload(submission))
+        self.assertEqual(cached["status"], "queued")
+
+    def test_status_transition_is_reflected_after_refresh(self):
+        submission = make_submission(status="queued")
+        refresh_job_cache(submission)
+        self.assertEqual(broadcast_cache.get_job_payload(str(submission.id))["status"], "queued")
+
+        submission.status = "running"
+        submission.save(update_fields=["status"])
+        refresh_job_cache(submission)
+
+        self.assertEqual(broadcast_cache.get_job_payload(str(submission.id))["status"], "running")
+
+    def test_terminal_states_are_cached_for_end_of_job_reads(self):
+        for terminal in ("done", "failed", "canceled"):
+            with self.subTest(status=terminal):
+                submission = make_submission(status="queued")
+                submission.status = terminal
+                submission.save(update_fields=["status"])
+                refresh_job_cache(submission)
+
+                cached = broadcast_cache.get_job_payload(str(submission.id))
+                self.assertIsNotNone(cached)
+                self.assertEqual(cached["status"], terminal)
+
+    def test_cancel_submission_updates_cache(self):
+        submission = make_submission(status="queued")
+        refresh_job_cache(submission)
+
+        cancel_submission(submission)
+
+        cached = broadcast_cache.get_job_payload(str(submission.id))
+        self.assertEqual(cached["status"], "canceled")
+
+    def test_retry_targets_requeues_cache(self):
+        submission = make_submission(status="failed")
+        submission.targets.update(status="failed", error="boom")
+        refresh_job_cache(submission)
+        self.assertEqual(broadcast_cache.get_job_payload(str(submission.id))["status"], "failed")
+
+        retry_targets(submission, ["a_site"])
+
+        cached = broadcast_cache.get_job_payload(str(submission.id))
+        self.assertEqual(cached["status"], "queued")
+        self.assertEqual(cached["targets"][0]["status"], "pending")
+
+    def test_create_submission_populates_cache(self):
+        event = CanonicalEvent(
+            title="T",
+            description="D",
+            start_datetime=datetime(2026, 7, 10, 19, 0, tzinfo=UTC),
+            venue_name="V",
+            address_line1="1 Main St",
+            city="Pittsboro",
+            zip="27312",
+            locality=["pittsboro"],
+            categories=["music"],
+        )
+        with mock.patch("broadcast.services._dispatch_worker"):
+            submission = create_submission(
+                client_label="test",
+                event=event,
+                site_keys=["a_site"],
+                dry_run=True,
+            )
+
+        cached = broadcast_cache.get_job_payload(str(submission.id))
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached["status"], "queued")
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+@tag("db")
+class JobDetailCacheReadTest(TestCase):
+    """GET /broadcast/jobs/{id} — a warm cache must be served without a
+    BroadcastSubmission SELECT."""
+
+    def setUp(self):
+        django_cache.clear()
+        self.client = APIClient()
+        BroadcastAccess.objects.create(email="makrs@example.com", tier=1)
+
+    def _get_job(self, job_id):
+        with _patch_jwt("makrs@example.com"):
+            return self.client.get(
+                f"/broadcast/jobs/{job_id}",
+                HTTP_AUTHORIZATION="Bearer faketoken",
+            )
+
+    def test_cold_cache_reads_db_and_populates_cache(self):
+        submission = make_submission(status="queued")
+        # Nothing cached yet.
+        self.assertIsNone(broadcast_cache.get_job_payload(str(submission.id)))
+
+        resp = self._get_job(submission.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "queued")
+
+        # The read-through populated the cache for the next poll.
+        cached = broadcast_cache.get_job_payload(str(submission.id))
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached["status"], "queued")
+
+    def test_warm_cache_read_skips_submission_select(self):
+        submission = make_submission(status="running")
+        refresh_job_cache(submission)
+
+        # Deleting the row proves the response cannot have come from the DB —
+        # only a cache hit could still return 200 with the right payload.
+        BroadcastSubmission.objects.filter(id=submission.id).delete()
+
+        resp = self._get_job(submission.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "running")
+
+    def test_unknown_job_still_404s(self):
+        resp = self._get_job("00000000-0000-0000-0000-000000000000")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_terminal_job_poll_served_from_cache_after_db_delete(self):
+        submission = make_submission(status="done")
+        submission.targets.update(status="succeeded")
+        refresh_job_cache(submission)
+
+        BroadcastSubmission.objects.filter(id=submission.id).delete()
+
+        resp = self._get_job(submission.id)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["status"], "done")
+        self.assertEqual(body["targets"][0]["status"], "succeeded")
+
+    def test_submit_then_poll_end_to_end_uses_cache(self):
+        """Full flow: POST /submit populates the cache via create_submission's
+        refresh_job_cache, then the very first GET poll is a cache hit."""
+        _make_code(raw="ENDTOEND")
+        submit_resp = self.client.post(
+            "/broadcast/submit",
+            {
+                "access_code": "ENDTOEND",
+                "event": {
+                    "title": "Dance Night",
+                    "description": "Social dancing.",
+                    "start_datetime": "2026-07-10T19:00:00-04:00",
+                    "venue_name": "The Plant",
+                    "address_line1": "220 Lorax Ln",
+                    "city": "Pittsboro",
+                    "state": "NC",
+                    "zip": "27312",
+                    "locality": ["pittsboro"],
+                    "categories": ["music"],
+                },
+                "site_keys": ["explore_pittsboro"],
+                "dry_run": True,
+            },
+            format="json",
+        )
+        self.assertEqual(submit_resp.status_code, 201)
+        job_id = submit_resp.json()["job_id"]
+
+        self.assertIsNotNone(broadcast_cache.get_job_payload(job_id))
+
+        # Prove the poll doesn't need the row: delete it, then poll.
+        BroadcastSubmission.objects.filter(id=job_id).delete()
+        resp = self._get_job(job_id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "queued")

--- a/backendServer/broadcast/views.py
+++ b/backendServer/broadcast/views.py
@@ -13,6 +13,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
+from broadcast import cache as broadcast_cache
 from broadcast.access import redeem_upgrade_code, resolve_access
 from broadcast.adapters import enabled_adapters, get_adapter, registry
 from broadcast.autofill import extract_event_fields
@@ -98,11 +99,20 @@ def submit(request):
 @api_view(["GET"])
 @permission_classes([RequiresBroadcastTier1])
 def job_detail(request, job_id):
+    """Poll target — broadcastWeb hits this every 3s while a job runs, so a
+    cache hit must never touch Neon. Miss path (cold cache) falls back to the
+    DB and repopulates the cache for subsequent polls."""
+    cached = broadcast_cache.get_job_payload(job_id)
+    if cached is not None:
+        return Response(cached)
+
     try:
         submission = BroadcastSubmission.objects.get(id=job_id)
     except BroadcastSubmission.DoesNotExist:
         raise Http404 from None
-    return Response(job_payload(submission))
+    payload = job_payload(submission)
+    broadcast_cache.set_job_payload(job_id, payload)
+    return Response(payload)
 
 
 @ratelimit(key="ip", rate="10/m", method="POST", block=True)

--- a/backendServer/broadcast/worker.py
+++ b/backendServer/broadcast/worker.py
@@ -13,6 +13,7 @@ from django.db import transaction
 
 from broadcast.models import BroadcastSubmission
 from broadcast.runner import run_submission
+from broadcast.services import refresh_job_cache
 
 logger = logging.getLogger("broadcast")
 
@@ -30,6 +31,7 @@ def claim_next() -> BroadcastSubmission | None:
             return None
         submission.status = "running"
         submission.save(update_fields=["status"])
+        refresh_job_cache(submission)
         return submission
 
 
@@ -48,6 +50,7 @@ def recover_orphans() -> int:
             submission.targets.filter(status="in_progress").update(status="pending")
             submission.status = "queued"
             submission.save(update_fields=["status"])
+            refresh_job_cache(submission)
             logger.warning("re-queued orphaned submission %s", submission.id)
     return len(orphans)
 
@@ -64,4 +67,5 @@ def run_once() -> bool:
         submission.refresh_from_db()
         submission.status = "failed"
         submission.save(update_fields=["status"])
+        refresh_job_cache(submission)
     return True

--- a/backendServer/devtools/monitoring.py
+++ b/backendServer/devtools/monitoring.py
@@ -1,0 +1,196 @@
+"""Pure query service for the devtools monitoring view.
+
+Turns real DB rows into per-collector / per-broadcast counts and drill-down
+rows. Every public function takes a `db` alias ("default" or
+"prod_readonly") and guards it against `settings.DATABASES` so an
+unconfigured `prod_readonly` degrades to an empty result instead of raising.
+Read-only: no `.save()`/`.delete()` anywhere in this module.
+"""
+
+from django.conf import settings
+from django.db.models import Count, Q
+
+from broadcast.models import BroadcastSubmission, BroadcastTarget
+from ingestion.models import EventSource, RawEvent, StagedEvent
+
+_STAGED_STATUSES = [choice[0] for choice in StagedEvent.STATUS_CHOICES]
+_SUBMISSION_STATUSES = [choice[0] for choice in BroadcastSubmission.STATUS_CHOICES]
+_TARGET_STATUSES = [choice[0] for choice in BroadcastTarget.STATUS_CHOICES]
+
+
+def _db_ok(db):
+    return db in settings.DATABASES
+
+
+def _iso(value):
+    return value.isoformat() if value is not None else None
+
+
+def _source_rows(db, start, end, source_type_filter):
+    sources = list(
+        EventSource.objects.using(db)
+        .filter(source_type_filter)
+        .order_by("name")
+        .values("id", "name", "source_type", "url", "active", "last_polled")
+    )
+    if not sources:
+        return []
+
+    source_ids = [s["id"] for s in sources]
+
+    raw_counts = {
+        row["source"]: row["n"]
+        for row in RawEvent.objects.using(db)
+        .filter(source_id__in=source_ids, created_at__gte=start, created_at__lt=end)
+        .values("source")
+        .annotate(n=Count("id"))
+    }
+
+    staged_qs = (
+        StagedEvent.objects.using(db)
+        .filter(
+            raw_event__source_id__in=source_ids,
+            raw_event__created_at__gte=start,
+            raw_event__created_at__lt=end,
+        )
+        .values("raw_event__source_id", "status")
+        .annotate(n=Count("id"))
+    )
+    staged_by_source = {}
+    for row in staged_qs:
+        source_id = row["raw_event__source_id"]
+        staged_by_source.setdefault(source_id, dict.fromkeys(_STAGED_STATUSES, 0))
+        staged_by_source[source_id][row["status"]] = row["n"]
+
+    published_counts = {
+        row["raw_event__source_id"]: row["n"]
+        for row in StagedEvent.objects.using(db)
+        .filter(
+            raw_event__source_id__in=source_ids,
+            raw_event__created_at__gte=start,
+            raw_event__created_at__lt=end,
+            published_event__isnull=False,
+        )
+        .values("raw_event__source_id")
+        .annotate(n=Count("id"))
+    }
+
+    results = []
+    for source in sources:
+        source_id = source["id"]
+        results.append(
+            {
+                "id": source_id,
+                "name": source["name"],
+                "source_type": source["source_type"],
+                "url": source["url"],
+                "active": source["active"],
+                "last_polled": _iso(source["last_polled"]),
+                "raw_count": raw_counts.get(source_id, 0),
+                "staged_by_status": staged_by_source.get(
+                    source_id, dict.fromkeys(_STAGED_STATUSES, 0)
+                ),
+                "published_count": published_counts.get(source_id, 0),
+            }
+        )
+    return results
+
+
+def collector_summary(db: str, start, end) -> list[dict]:
+    if not _db_ok(db):
+        return []
+    return _source_rows(db, start, end, ~Q(source_type="direct"))
+
+
+def broadcast_inbound_summary(db: str, start, end) -> list[dict]:
+    if not _db_ok(db):
+        return []
+    return _source_rows(db, start, end, Q(source_type="direct"))
+
+
+def broadcast_outbound_summary(db: str, start, end) -> dict:
+    if not _db_ok(db):
+        return {}
+
+    submissions = BroadcastSubmission.objects.using(db).filter(
+        created_at__gte=start, created_at__lt=end
+    )
+
+    by_status = dict.fromkeys(_SUBMISSION_STATUSES, 0)
+    total = 0
+    for row in submissions.values("status").annotate(n=Count("id")):
+        by_status[row["status"]] = row["n"]
+        total += row["n"]
+
+    targets_by_status = dict.fromkeys(_TARGET_STATUSES, 0)
+    target_rows = (
+        BroadcastTarget.objects.using(db)
+        .filter(submission__in=submissions)
+        .values("status")
+        .annotate(n=Count("id"))
+    )
+    for row in target_rows:
+        targets_by_status[row["status"]] = row["n"]
+
+    return {"by_status": by_status, "total": total, "targets_by_status": targets_by_status}
+
+
+def _drilldown_source(db, key, start, end, limit):
+    raw_events = list(
+        RawEvent.objects.using(db)
+        .filter(source_id=key, created_at__gte=start, created_at__lt=end)
+        .select_related("staged")
+        .order_by("-created_at")[:limit]
+    )
+    rows = []
+    for raw in raw_events:
+        staged = getattr(raw, "staged", None)
+        rows.append(
+            {
+                "raw_id": raw.id,
+                "raw_title": raw.raw_title,
+                "raw_created_at": _iso(raw.created_at),
+                "processed": raw.processed,
+                "staged_status": staged.status if staged else None,
+                "published": bool(staged and staged.published_event_id),
+            }
+        )
+    return rows
+
+
+def _drilldown_outbound(db, key, start, end, limit):
+    submissions_qs = BroadcastSubmission.objects.using(db).filter(
+        created_at__gte=start, created_at__lt=end
+    )
+    if key:
+        submissions_qs = submissions_qs.filter(targets__site_key=key).distinct()
+
+    submissions = list(submissions_qs.order_by("-created_at").prefetch_related("targets")[:limit])
+
+    rows = []
+    for submission in submissions:
+        rows.append(
+            {
+                "submission_id": str(submission.id),
+                "title": submission.title,
+                "client_label": submission.client_label,
+                "status": submission.status,
+                "created_at": _iso(submission.created_at),
+                "targets": [
+                    {"site_key": target.site_key, "status": target.status}
+                    for target in submission.targets.all()
+                ],
+            }
+        )
+    return rows
+
+
+def drilldown(db: str, kind: str, key, start, end, limit: int = 100) -> list[dict]:
+    if not _db_ok(db):
+        return []
+
+    if kind in ("collector", "inbound"):
+        return _drilldown_source(db, key, start, end, limit)
+    if kind == "outbound":
+        return _drilldown_outbound(db, key, start, end, limit)
+    return []

--- a/backendServer/devtools/templates/devtools/index.html
+++ b/backendServer/devtools/templates/devtools/index.html
@@ -54,6 +54,12 @@
         Preview events as they appear on the site before committing anything to the database.
       </p>
     </li>
+    <li class="tool-item">
+      <p class="tool-name"><a href="/devtools/monitor">Ingestion &amp; Broadcast Monitor</a></p>
+      <p class="tool-desc">
+        Per-collector and broadcast event counts with drill-down; switch between dev and prod DBs.
+      </p>
+    </li>
   </ul>
 </div>
 {% endblock %}

--- a/backendServer/devtools/templates/devtools/monitor.html
+++ b/backendServer/devtools/templates/devtools/monitor.html
@@ -1,0 +1,271 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Ingestion & Broadcast Monitor — Devtools{% endblock %}
+
+{% block content %}
+<style>
+  .monitor { max-width: 1100px; }
+  .monitor h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 0.5rem; }
+  .monitor h2 { font-size: 1.15rem; font-weight: 700; margin: 2rem 0 0.75rem; }
+  .monitor .description { color: #6b7280; margin: 0.5rem 0 1.5rem; line-height: 1.65; }
+
+  .monitor .controls {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+  }
+  .monitor .controls label { font-size: 0.8rem; font-weight: 600; display: inline-flex; align-items: center; gap: 0.4rem; cursor: pointer; }
+  .monitor .controls select { padding: 0.3rem 0.5rem; border: 1px solid #d1d5db; border-radius: 4px; font-size: 0.85rem; }
+  .monitor .controls .db-label.prod-active { color: #dc2626; }
+
+  .monitor table { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-bottom: 0.5rem; }
+  .monitor th, .monitor td { border: 1px solid #e5e7eb; padding: 0.4rem 0.6rem; text-align: left; }
+  .monitor th { background: #f3f4f6; font-weight: 700; }
+  .monitor tr.source-row { cursor: pointer; }
+  .monitor tr.source-row:hover { background: #f9fafb; }
+  .monitor tr.source-row.inactive { color: #9ca3af; }
+  .monitor td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .monitor .empty-note { color: #6b7280; font-size: 0.85rem; margin: 0.5rem 0 1rem; }
+
+  .monitor .summary-stats { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  .monitor .stat { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0.5rem 0.9rem; font-size: 0.85rem; }
+  .monitor .stat strong { display: block; font-size: 1.15rem; }
+
+  .monitor .drilldown-row td { background: #fafafa; padding: 0; }
+  .monitor .drilldown-wrap { padding: 0.75rem 1rem; }
+  .monitor .drilldown-wrap .loading { color: #6b7280; font-size: 0.8rem; }
+  .monitor .drilldown-wrap table { margin-bottom: 0; }
+  .monitor .badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.75rem; background: #e5e7eb; }
+  .monitor .badge.published, .monitor .badge.succeeded, .monitor .badge.done, .monitor .badge.approved { background: #dcfce7; color: #166534; }
+  .monitor .badge.rejected, .monitor .badge.failed, .monitor .badge.canceled { background: #fee2e2; color: #991b1b; }
+  .monitor .badge.pending, .monitor .badge.queued, .monitor .badge.running, .monitor .badge.in_progress { background: #fef3c7; color: #92400e; }
+  .monitor .badge.duplicate, .monitor .badge.skipped, .monitor .badge.needs_manual { background: #e0e7ff; color: #3730a3; }
+</style>
+
+<div class="monitor">
+  <h1>Ingestion &amp; Broadcast Monitor</h1>
+  <p class="description">
+    Per-collector and per-broadcast event counts for the selected window. Click a row to see the
+    underlying raw events (or broadcast submissions).
+  </p>
+
+  <div class="controls">
+    <label>
+      Window
+      <select id="window-select">
+        <option value="7d" {% if window == "7d" %}selected{% endif %}>Last 7 days</option>
+        <option value="30d" {% if window == "30d" %}selected{% endif %}>Last 30 days</option>
+        <option value="90d" {% if window == "90d" %}selected{% endif %}>Last 90 days</option>
+      </select>
+    </label>
+    <label>
+      <input type="checkbox" id="db-toggle" style="width:auto;" {% if db == "prod_readonly" %}checked{% endif %} {% if not prod_readonly_configured %}disabled{% endif %} />
+      <span class="db-label {% if db == 'prod_readonly' %}prod-active{% endif %}" id="db-toggle-label">
+        {% if prod_readonly_configured %}Prod DB (read-only){% else %}Prod DB (not configured){% endif %}
+      </span>
+    </label>
+  </div>
+
+  <h2>Collectors</h2>
+  {% if collectors %}
+  <table id="collectors-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Active</th>
+        <th>Last polled</th>
+        <th class="num">Raw</th>
+        <th class="num">Pending</th>
+        <th class="num">Approved</th>
+        <th class="num">Rejected</th>
+        <th class="num">Duplicate</th>
+        <th class="num">Published</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in collectors %}
+      <tr class="source-row {% if not c.active %}inactive{% endif %}" data-kind="collector" data-key="{{ c.id }}">
+        <td>{{ c.name }}</td>
+        <td>{{ c.source_type }}</td>
+        <td>{{ c.active|yesno:"yes,no" }}</td>
+        <td>{{ c.last_polled|default:"—" }}</td>
+        <td class="num">{{ c.raw_count }}</td>
+        <td class="num">{{ c.staged_by_status.pending }}</td>
+        <td class="num">{{ c.staged_by_status.approved }}</td>
+        <td class="num">{{ c.staged_by_status.rejected }}</td>
+        <td class="num">{{ c.staged_by_status.duplicate }}</td>
+        <td class="num">{{ c.published_count }}</td>
+      </tr>
+      <tr class="drilldown-row" data-for="collector:{{ c.id }}" style="display:none;"><td colspan="10"></td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-note">No collectors found for this window/database.</p>
+  {% endif %}
+
+  <h2>Broadcast — inbound (direct submissions)</h2>
+  {% if inbound %}
+  <table id="inbound-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Active</th>
+        <th>Last polled</th>
+        <th class="num">Raw</th>
+        <th class="num">Pending</th>
+        <th class="num">Approved</th>
+        <th class="num">Rejected</th>
+        <th class="num">Duplicate</th>
+        <th class="num">Published</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in inbound %}
+      <tr class="source-row {% if not c.active %}inactive{% endif %}" data-kind="inbound" data-key="{{ c.id }}">
+        <td>{{ c.name }}</td>
+        <td>{{ c.active|yesno:"yes,no" }}</td>
+        <td>{{ c.last_polled|default:"—" }}</td>
+        <td class="num">{{ c.raw_count }}</td>
+        <td class="num">{{ c.staged_by_status.pending }}</td>
+        <td class="num">{{ c.staged_by_status.approved }}</td>
+        <td class="num">{{ c.staged_by_status.rejected }}</td>
+        <td class="num">{{ c.staged_by_status.duplicate }}</td>
+        <td class="num">{{ c.published_count }}</td>
+      </tr>
+      <tr class="drilldown-row" data-for="inbound:{{ c.id }}" style="display:none;"><td colspan="9"></td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-note">No direct/inbound submissions for this window/database.</p>
+  {% endif %}
+
+  <h2>Broadcast — outbound (syndication)</h2>
+  <div class="summary-stats">
+    <div class="stat"><strong>{{ outbound.total|default:0 }}</strong>submissions</div>
+    {% for status, count in outbound.by_status.items %}
+    <div class="stat"><strong>{{ count }}</strong>{{ status }}</div>
+    {% endfor %}
+  </div>
+  <div class="summary-stats">
+    {% for status, count in outbound.targets_by_status.items %}
+    <div class="stat"><strong>{{ count }}</strong>targets: {{ status }}</div>
+    {% endfor %}
+  </div>
+  <table id="outbound-table">
+    <tbody>
+      <tr class="source-row" data-kind="outbound" data-key="">
+        <td>All outbound submissions in window</td>
+      </tr>
+      <tr class="drilldown-row" data-for="outbound:" style="display:none;"><td colspan="1"></td></tr>
+    </tbody>
+  </table>
+</div>
+
+<script>
+(function () {
+  var windowSelect = document.getElementById("window-select");
+  var dbToggle = document.getElementById("db-toggle");
+  var dbToggleLabel = document.getElementById("db-toggle-label");
+
+  function currentDb() {
+    return (dbToggle && dbToggle.checked) ? "prod_readonly" : "default";
+  }
+
+  function reload() {
+    var params = new URLSearchParams();
+    params.set("db", currentDb());
+    params.set("window", windowSelect.value);
+    window.location.search = params.toString();
+  }
+
+  if (windowSelect) {
+    windowSelect.addEventListener("change", reload);
+  }
+  if (dbToggle) {
+    dbToggle.addEventListener("change", reload);
+  }
+  if (dbToggleLabel && dbToggle && dbToggle.checked) {
+    dbToggleLabel.classList.add("prod-active");
+  }
+
+  var STATUS_KEYS = ["published", "approved", "succeeded", "done", "rejected", "failed", "canceled",
+    "pending", "queued", "running", "in_progress", "duplicate", "skipped", "needs_manual"];
+
+  function badge(status) {
+    if (!status) return "—";
+    return '<span class="badge ' + status + '">' + status + "</span>";
+  }
+
+  function renderSourceDrilldown(rows) {
+    if (!rows.length) return '<p class="empty-note">No raw events in this window.</p>';
+    var html = "<table><thead><tr><th>Title</th><th>Created</th><th>Processed</th><th>Staged status</th><th>Published</th></tr></thead><tbody>";
+    rows.forEach(function (r) {
+      html += "<tr><td>" + (r.raw_title || "") + "</td><td>" + (r.raw_created_at || "") + "</td>" +
+        "<td>" + (r.processed ? "yes" : "no") + "</td><td>" + badge(r.staged_status) + "</td>" +
+        "<td>" + (r.published ? badge("published") : "no") + "</td></tr>";
+    });
+    html += "</tbody></table>";
+    return html;
+  }
+
+  function renderOutboundDrilldown(rows) {
+    if (!rows.length) return '<p class="empty-note">No submissions in this window.</p>';
+    var html = "<table><thead><tr><th>Title</th><th>Client</th><th>Status</th><th>Created</th><th>Targets</th></tr></thead><tbody>";
+    rows.forEach(function (r) {
+      var targets = (r.targets || []).map(function (t) {
+        return t.site_key + " " + badge(t.status);
+      }).join("<br>");
+      html += "<tr><td>" + (r.title || "") + "</td><td>" + (r.client_label || "") + "</td>" +
+        "<td>" + badge(r.status) + "</td><td>" + (r.created_at || "") + "</td><td>" + targets + "</td></tr>";
+    });
+    html += "</tbody></table>";
+    return html;
+  }
+
+  document.querySelectorAll("tr.source-row").forEach(function (row) {
+    row.addEventListener("click", function () {
+      var kind = row.getAttribute("data-kind");
+      var key = row.getAttribute("data-key");
+      var drilldownRow = document.querySelector('tr.drilldown-row[data-for="' + kind + ":" + key + '"]');
+      if (!drilldownRow) return;
+
+      var isOpen = drilldownRow.style.display !== "none";
+      if (isOpen) {
+        drilldownRow.style.display = "none";
+        return;
+      }
+
+      var cell = drilldownRow.querySelector("td");
+      cell.innerHTML = '<div class="drilldown-wrap"><span class="loading">Loading…</span></div>';
+      drilldownRow.style.display = "";
+
+      var params = new URLSearchParams();
+      params.set("db", currentDb());
+      params.set("window", windowSelect.value);
+      params.set("kind", kind);
+      params.set("key", key);
+
+      fetch("/devtools/monitor/data?" + params.toString())
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          var rows = data.rows || [];
+          var body = kind === "outbound" ? renderOutboundDrilldown(rows) : renderSourceDrilldown(rows);
+          cell.innerHTML = '<div class="drilldown-wrap">' + body + "</div>";
+        })
+        .catch(function () {
+          cell.innerHTML = '<div class="drilldown-wrap"><span class="empty-note">Failed to load.</span></div>';
+        });
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/backendServer/devtools/tests/test_monitor_view_db.py
+++ b/backendServer/devtools/tests/test_monitor_view_db.py
@@ -1,0 +1,132 @@
+import json
+from datetime import timedelta
+
+from django.http import Http404
+from django.test import RequestFactory, TestCase, override_settings, tag
+from django.utils import timezone
+
+from devtools.views import monitor, monitor_data
+from events.tests.factories import make_event
+from ingestion.models import EventSource, RawEvent, StagedEvent
+
+
+@tag("db")
+class MonitorViewTests(TestCase):
+    """Exercises the monitor/monitor_data views directly via RequestFactory.
+
+    The `devtools/` URLs are only mounted when settings.DEBUG is True
+    (backend/urls.py), and override_settings does not reload the URLConf,
+    so routing through the test client can't reach the view under the
+    test settings. Calling the view function directly sidesteps that,
+    mirroring devtools/tests/test_add_source_db.py.
+    """
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.now = timezone.now()
+
+        self.source = EventSource.objects.create(
+            name="Monitor Test Collector",
+            source_type="ics",
+            url="https://monitor.example.com/feed.ics",
+        )
+        raw = RawEvent.objects.create(
+            source=self.source, raw_title="Test Raw", raw_start=self.now, source_uid="mt1"
+        )
+        event = make_event(title="Monitor Published Event")
+        StagedEvent.objects.create(
+            raw_event=raw,
+            title="Test Raw",
+            description="d",
+            location_name="l",
+            town="carrboro",
+            start_datetime=self.now,
+            status="approved",
+            published_event=event,
+        )
+
+    def _get(self, path, params=None):
+        return self.factory.get(path, params or {})
+
+    @override_settings(DEBUG=True)
+    def test_monitor_returns_200_in_debug(self):
+        resp = monitor(self._get("/devtools/monitor"))
+        self.assertEqual(resp.status_code, 200)
+
+    @override_settings(DEBUG=False)
+    def test_monitor_raises_404_when_not_debug(self):
+        with self.assertRaises(Http404):
+            monitor(self._get("/devtools/monitor"))
+
+    @override_settings(DEBUG=True)
+    def test_monitor_renders_real_counts(self):
+        resp = monitor(self._get("/devtools/monitor", {"window": "30d"}))
+        self.assertEqual(resp.status_code, 200)
+        content = resp.content.decode()
+        self.assertIn("Monitor Test Collector", content)
+
+    @override_settings(DEBUG=True)
+    def test_monitor_data_returns_200_with_rows(self):
+        resp = monitor_data(
+            self._get(
+                "/devtools/monitor/data",
+                {"kind": "collector", "key": str(self.source.id), "window": "30d"},
+            )
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertIn("rows", data)
+        self.assertEqual(len(data["rows"]), 1)
+        self.assertEqual(data["rows"][0]["raw_title"], "Test Raw")
+        self.assertEqual(data["db"], "default")
+
+    @override_settings(DEBUG=True)
+    def test_monitor_data_invalid_kind_returns_400(self):
+        resp = monitor_data(self._get("/devtools/monitor/data", {"kind": "bogus"}))
+        self.assertEqual(resp.status_code, 400)
+
+    @override_settings(DEBUG=False)
+    def test_monitor_data_raises_404_when_not_debug(self):
+        with self.assertRaises(Http404):
+            monitor_data(self._get("/devtools/monitor/data", {"kind": "collector"}))
+
+    @override_settings(DEBUG=True)
+    def test_monitor_data_outbound_all_sites(self):
+        resp = monitor_data(
+            self._get("/devtools/monitor/data", {"kind": "outbound", "key": "", "window": "30d"})
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertIn("rows", data)
+
+    @override_settings(DEBUG=True)
+    def test_monitor_data_bad_db_falls_back_to_default(self):
+        resp = monitor_data(
+            self._get(
+                "/devtools/monitor/data",
+                {"kind": "collector", "key": str(self.source.id), "db": "not_a_real_db"},
+            )
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["db"], "default")
+
+    @override_settings(DEBUG=True)
+    def test_monitor_window_param_narrows_results(self):
+        old_raw = RawEvent.objects.create(
+            source=self.source,
+            raw_title="Old Raw",
+            raw_start=self.now,
+            source_uid="old1",
+        )
+        RawEvent.objects.filter(pk=old_raw.pk).update(created_at=self.now - timedelta(days=60))
+
+        resp = monitor_data(
+            self._get(
+                "/devtools/monitor/data",
+                {"kind": "collector", "key": str(self.source.id), "window": "7d"},
+            )
+        )
+        data = json.loads(resp.content)
+        titles = [r["raw_title"] for r in data["rows"]]
+        self.assertNotIn("Old Raw", titles)

--- a/backendServer/devtools/tests/test_monitoring_db.py
+++ b/backendServer/devtools/tests/test_monitoring_db.py
@@ -1,0 +1,239 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.test import TestCase, override_settings, tag
+from django.utils import timezone
+
+from broadcast.models import BroadcastSubmission, BroadcastTarget
+from devtools.monitoring import (
+    broadcast_inbound_summary,
+    broadcast_outbound_summary,
+    collector_summary,
+    drilldown,
+)
+from events.tests.factories import make_event
+from ingestion.models import EventSource, RawEvent, StagedEvent
+
+
+@tag("db")
+class MonitoringQueryServiceTests(TestCase):
+    """Exercises devtools/monitoring.py against real rows in the test Postgres DB.
+
+    Window is [start, end) on RawEvent.created_at / BroadcastSubmission.created_at.
+    `created_at` is `auto_now_add`, so rows created in setUp all land "now" —
+    the window in each test is padded generously around `timezone.now()`.
+    """
+
+    def setUp(self):
+        self.now = timezone.now()
+        self.start = self.now - timedelta(days=1)
+        self.end = self.now + timedelta(days=1)
+
+        self.collector_a = EventSource.objects.create(
+            name="Collector A", source_type="ics", url="https://a.example.com/feed.ics"
+        )
+        self.collector_b = EventSource.objects.create(
+            name="Collector B", source_type="scraper", url="https://b.example.com/events"
+        )
+        self.direct_source = EventSource.objects.create(
+            name="Direct Host Submission", source_type="direct", url="https://commons.local/direct"
+        )
+
+        event = make_event(title="Published via A")
+
+        # Collector A: 3 raw events -> 1 pending, 1 approved+published, 1 rejected
+        raw_a1 = RawEvent.objects.create(
+            source=self.collector_a, raw_title="A1", raw_start=self.now, source_uid="a1"
+        )
+        StagedEvent.objects.create(
+            raw_event=raw_a1,
+            title="A1",
+            description="d",
+            location_name="l",
+            town="carrboro",
+            start_datetime=self.now,
+            status="pending",
+        )
+        raw_a2 = RawEvent.objects.create(
+            source=self.collector_a,
+            raw_title="A2",
+            raw_start=self.now,
+            processed=True,
+            source_uid="a2",
+        )
+        StagedEvent.objects.create(
+            raw_event=raw_a2,
+            title="A2",
+            description="d",
+            location_name="l",
+            town="carrboro",
+            start_datetime=self.now,
+            status="approved",
+            published_event=event,
+        )
+        raw_a3 = RawEvent.objects.create(
+            source=self.collector_a, raw_title="A3", raw_start=self.now, source_uid="a3"
+        )
+        StagedEvent.objects.create(
+            raw_event=raw_a3,
+            title="A3",
+            description="d",
+            location_name="l",
+            town="carrboro",
+            start_datetime=self.now,
+            status="rejected",
+        )
+
+        # Collector B: 1 raw event, no staged row yet
+        RawEvent.objects.create(
+            source=self.collector_b, raw_title="B1", raw_start=self.now, source_uid="b1"
+        )
+
+        # Direct source: 1 raw event, duplicate status
+        raw_d1 = RawEvent.objects.create(
+            source=self.direct_source, raw_title="D1", raw_start=self.now, source_uid="d1"
+        )
+        StagedEvent.objects.create(
+            raw_event=raw_d1,
+            title="D1",
+            description="d",
+            location_name="l",
+            town="carrboro",
+            start_datetime=self.now,
+            status="duplicate",
+        )
+
+        # Broadcast submission with mixed-status targets
+        self.submission = BroadcastSubmission.objects.create(
+            client_label="client-1",
+            title="Broadcast Event",
+            description="desc",
+            start_datetime=self.now,
+            venue_name="Venue",
+            address_line1="123 Main St",
+            zip="27510",
+            status="done",
+        )
+        BroadcastTarget.objects.create(
+            submission=self.submission, site_key="site-one", status="succeeded"
+        )
+        BroadcastTarget.objects.create(
+            submission=self.submission, site_key="site-two", status="failed"
+        )
+
+    def test_collector_summary_counts_are_exact(self):
+        rows = {r["name"]: r for r in collector_summary("default", self.start, self.end)}
+
+        self.assertEqual(set(rows.keys()), {"Collector A", "Collector B"})
+
+        a = rows["Collector A"]
+        self.assertEqual(a["source_type"], "ics")
+        self.assertEqual(a["raw_count"], 3)
+        self.assertEqual(
+            a["staged_by_status"],
+            {"pending": 1, "approved": 1, "rejected": 1, "duplicate": 0},
+        )
+        self.assertEqual(a["published_count"], 1)
+
+        b = rows["Collector B"]
+        self.assertEqual(b["raw_count"], 1)
+        self.assertEqual(
+            b["staged_by_status"],
+            {"pending": 0, "approved": 0, "rejected": 0, "duplicate": 0},
+        )
+        self.assertEqual(b["published_count"], 0)
+
+    def test_direct_source_excluded_from_collector_summary(self):
+        names = [r["name"] for r in collector_summary("default", self.start, self.end)]
+        self.assertNotIn("Direct Host Submission", names)
+
+    def test_direct_source_only_in_inbound_summary(self):
+        rows = broadcast_inbound_summary("default", self.start, self.end)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["name"], "Direct Host Submission")
+        self.assertEqual(row["source_type"], "direct")
+        self.assertEqual(row["raw_count"], 1)
+        self.assertEqual(
+            row["staged_by_status"],
+            {"pending": 0, "approved": 0, "rejected": 0, "duplicate": 1},
+        )
+        self.assertEqual(row["published_count"], 0)
+
+    def test_broadcast_outbound_summary_counts(self):
+        result = broadcast_outbound_summary("default", self.start, self.end)
+        self.assertEqual(result["total"], 1)
+        self.assertEqual(
+            result["by_status"],
+            {"queued": 0, "running": 0, "done": 1, "failed": 0, "canceled": 0},
+        )
+        self.assertEqual(
+            result["targets_by_status"],
+            {
+                "pending": 0,
+                "in_progress": 0,
+                "succeeded": 1,
+                "failed": 1,
+                "needs_manual": 0,
+                "skipped": 0,
+            },
+        )
+
+    def test_drilldown_collector_returns_rows_most_recent_first(self):
+        rows = drilldown("default", "collector", self.collector_a.id, self.start, self.end)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0]["raw_title"], "A3")
+        self.assertEqual(rows[-1]["raw_title"], "A1")
+
+        published_row = next(r for r in rows if r["raw_title"] == "A2")
+        self.assertEqual(published_row["staged_status"], "approved")
+        self.assertTrue(published_row["published"])
+        self.assertTrue(published_row["processed"])
+
+        pending_row = next(r for r in rows if r["raw_title"] == "A1")
+        self.assertEqual(pending_row["staged_status"], "pending")
+        self.assertFalse(pending_row["published"])
+
+    def test_drilldown_respects_limit(self):
+        rows = drilldown("default", "collector", self.collector_a.id, self.start, self.end, limit=2)
+        self.assertEqual(len(rows), 2)
+
+    def test_drilldown_inbound_uses_direct_source(self):
+        rows = drilldown("default", "inbound", self.direct_source.id, self.start, self.end)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["raw_title"], "D1")
+        self.assertEqual(rows[0]["staged_status"], "duplicate")
+
+    def test_drilldown_outbound_all_sites(self):
+        rows = drilldown("default", "outbound", None, self.start, self.end)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["submission_id"], str(self.submission.id))
+        self.assertEqual(row["title"], "Broadcast Event")
+        self.assertEqual(row["status"], "done")
+        site_keys = {t["site_key"] for t in row["targets"]}
+        self.assertEqual(site_keys, {"site-one", "site-two"})
+
+    def test_drilldown_outbound_filters_by_site_key(self):
+        rows = drilldown("default", "outbound", "site-one", self.start, self.end)
+        self.assertEqual(len(rows), 1)
+
+        rows = drilldown("default", "outbound", "nonexistent-site", self.start, self.end)
+        self.assertEqual(rows, [])
+
+    def test_unconfigured_prod_readonly_returns_empty_not_crash(self):
+        """Force `prod_readonly` out of DATABASES (this dev env may have it set via
+        PROD_DATABASE_URL) to exercise the guard that keeps an unconfigured alias
+        from ever raising.
+        """
+        databases_without_prod = {
+            k: v for k, v in settings.DATABASES.items() if k != "prod_readonly"
+        }
+        with override_settings(DATABASES=databases_without_prod):
+            self.assertEqual(collector_summary("prod_readonly", self.start, self.end), [])
+            self.assertEqual(broadcast_inbound_summary("prod_readonly", self.start, self.end), [])
+            self.assertEqual(broadcast_outbound_summary("prod_readonly", self.start, self.end), {})
+            self.assertEqual(
+                drilldown("prod_readonly", "collector", self.collector_a.id, self.start, self.end),
+                [],
+            )

--- a/backendServer/devtools/urls.py
+++ b/backendServer/devtools/urls.py
@@ -11,4 +11,6 @@ urlpatterns = [
     path("add-source", views.add_source, name="add_source"),
     path("publish-events-only", views.publish_events_only, name="publish_events_only"),
     path("sources", views.sources_api, name="sources_api"),
+    path("monitor", views.monitor, name="monitor"),
+    path("monitor/data", views.monitor_data, name="monitor_data"),
 ]

--- a/backendServer/devtools/views.py
+++ b/backendServer/devtools/views.py
@@ -2,12 +2,14 @@ import ipaddress
 import queue
 import socket
 import threading
+from datetime import timedelta
 from urllib.parse import urlparse
 
 from django.conf import settings
 from django.db import transaction
 from django.http import Http404, HttpResponseBadRequest, JsonResponse, StreamingHttpResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_protect
 
 from events.models import Event, Town
@@ -20,12 +22,22 @@ from ingestion.scraping.scrapers import list_scrapers
 from ingestion.services import auto_publish_safe_events
 from ingestion.standardizer import standardize_all_unprocessed
 
+from .monitoring import (
+    broadcast_inbound_summary,
+    broadcast_outbound_summary,
+    collector_summary,
+    drilldown,
+)
 from .pipeline_runner import _event_dict, _resolve_source_name, run_pipeline_into_queue
 from .sse import sse_frame
 
 # ── SSRF guard ────────────────────────────────────────────────────────────────
 
 _BLOCKED_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "169.254.169.254"}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+_WINDOW_DAYS = {"7d": 7, "30d": 30, "90d": 90}
 
 
 def _validate_url(url):
@@ -335,3 +347,64 @@ def add_source(request):
             "name": source.name,
         }
     )
+
+
+def _resolve_db(request):
+    db = request.GET.get("db", "default")
+    if db not in ("default", "prod_readonly") or db not in settings.DATABASES:
+        db = "default"
+    return db
+
+
+def _resolve_window(request):
+    window = request.GET.get("window", "30d")
+    if window not in _WINDOW_DAYS:
+        window = "30d"
+    end = timezone.now()
+    start = end - timedelta(days=_WINDOW_DAYS[window])
+    return window, start, end
+
+
+def monitor(request):
+    if not settings.DEBUG:
+        raise Http404
+
+    db = _resolve_db(request)
+    window, start, end = _resolve_window(request)
+
+    return render(
+        request,
+        "devtools/monitor.html",
+        {
+            "collectors": collector_summary(db, start, end),
+            "inbound": broadcast_inbound_summary(db, start, end),
+            "outbound": broadcast_outbound_summary(db, start, end),
+            "db": db,
+            "window": window,
+            "prod_readonly_configured": "prod_readonly" in settings.DATABASES,
+        },
+    )
+
+
+def monitor_data(request):
+    if not settings.DEBUG:
+        raise Http404
+
+    kind = request.GET.get("kind", "")
+    if kind not in ("collector", "inbound", "outbound"):
+        return JsonResponse({"error": f"invalid kind '{kind}'"}, status=400)
+
+    db = _resolve_db(request)
+    _, start, end = _resolve_window(request)
+
+    key = request.GET.get("key", "")
+    if kind != "outbound":
+        key = int(key) if key.isdigit() else None
+    else:
+        key = key or None
+
+    limit_raw = request.GET.get("limit", "").strip()
+    limit = min(int(limit_raw), 100) if limit_raw.isdigit() else 100
+
+    rows = drilldown(db, kind, key, start, end, limit=limit)
+    return JsonResponse({"rows": rows, "db": db})

--- a/broadcastWeb/src/App.tsx
+++ b/broadcastWeb/src/App.tsx
@@ -895,7 +895,7 @@ export default function App() {
                       <span className="target-status pending">opening…</span>
                     )}
                     {status === "submitted" && (
-                      <span className="target-status submitted">submitted</span>
+                      <span className="target-status submitted">filled</span>
                     )}
                     {status === "unavailable" && (
                       <span className="target-status unavailable">not available</span>
@@ -968,7 +968,7 @@ export default function App() {
                     }}
                     disabled={busy || selected.size === 0}
                   >
-                    Submit events!
+                    Populate Forms!
                   </button>
                 </div>
               )}

--- a/broadcastWeb/src/styles/app.css
+++ b/broadcastWeb/src/styles/app.css
@@ -553,7 +553,7 @@ button.verify.is-verified {
 .optional-unfilled {
   font-size: 0.78rem;
   font-style: italic;
-  color: var(--color-text-muted);
+  color: var(--color-accent);
 }
 
 /* Anchor styled as a button — used for external links in action rows */

--- a/docs/dev-db-isolation.md
+++ b/docs/dev-db-isolation.md
@@ -101,3 +101,85 @@ The idea of keeping both `DATABASE_URL` (dev) and `DATABASE_URL_PROD` (prod) in 
 - [ ] Run `python manage.py migrate` against dev branch
 - [ ] Run `python manage.py seed_dev`
 - [ ] Verify frontend auth signup creates a row in the dev branch, not prod
+
+---
+
+## Monitoring Prod Read-Only from Local Dev
+
+`backend/settings/dev.py:39-52` defines an optional second DB alias, `prod_readonly`, populated from `PROD_DATABASE_URL` when that env var is set. This exists so local devtools (e.g. an "Ingestion & Broadcast Monitor" page, selected via a `?db=prod_readonly` query param) can inspect real prod data — sources, ingestion runs, broadcast queue state — without routing writes through it and without merging prod into the `default` dev-branch alias above.
+
+This only works safely if the credentials behind `PROD_DATABASE_URL` are **read-only**. `dev.py` does not enforce that at the Django layer — it will happily use a read-write DSN if you give it one. The enforcement has to happen at the Postgres role level, on the Neon prod branch itself. Follow this checklist before setting `PROD_DATABASE_URL` anywhere.
+
+### 1. Create a read-only role on the Neon prod branch
+
+Neon's console (**Project → prod branch → Roles**) can create a role for you, but it won't scope permissions — by default a new Neon role can still write. Use SQL instead, run against the **prod** branch via `psql` or the Neon SQL editor:
+
+```sql
+-- Run against the PROD branch, as an owner/admin role
+CREATE ROLE monitor_readonly LOGIN PASSWORD '<generate-a-strong-password>';
+
+GRANT CONNECT ON DATABASE neondb TO monitor_readonly;
+GRANT USAGE ON SCHEMA public TO monitor_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO monitor_readonly;
+
+-- So tables created *after* this grant are still read-only for the role
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO monitor_readonly;
+```
+
+Notes:
+- Do **not** grant `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `CREATE`, or anything on `SCHEMA neon_auth` unless a specific read need shows up later — start minimal.
+- If you used the Neon console's Roles UI to create the role, still run the `GRANT`/`ALTER DEFAULT PRIVILEGES` statements above by hand — the UI doesn't offer a "read-only" toggle.
+- Name the role something that signals its purpose (`monitor_readonly`, `devtools_ro`, etc.) so it's obvious in Neon's role list and in any future audit.
+
+### 2. Get the role's connection string
+
+In the Neon console, switch the "connect" panel's role/user dropdown to `monitor_readonly` (still on the **prod** branch) and copy the connection string. It has the same host as prod's main DSN but a different `user`/`password`.
+
+### 3. Set `PROD_DATABASE_URL` in `backendServer/.env`
+
+```
+PROD_DATABASE_URL=postgresql://monitor_readonly:<password>@<prod-branch-host>/neondb?sslmode=require
+```
+
+Leave `DATABASE_URL` in the same file pointed at your dev branch, per the "On Dual Connection Strings" guidance above — `PROD_DATABASE_URL` is a separate, additive variable, not a replacement.
+
+### 4. Confirm the `prod_readonly` alias connects
+
+```bash
+cd backendServer
+DJANGO_ENV=dev uv run python manage.py dbshell --database=prod_readonly
+```
+
+Or, without dropping into `psql`, from `manage.py shell`:
+
+```python
+from django.db import connections
+connections["prod_readonly"].ensure_connection()
+print("connected:", connections["prod_readonly"].is_usable())
+```
+
+A successful connection confirms the DSN and role are wired correctly on the Django side.
+
+### 5. Verify the role actually cannot write
+
+This is the step that matters most — don't skip it. In the same `dbshell --database=prod_readonly` session, try something harmless and destructive-shaped:
+
+```sql
+CREATE TABLE ro_smoke_test (id int);
+-- expected: ERROR: permission denied for schema public
+
+INSERT INTO events_event (id) VALUES (-1);
+-- expected: ERROR: permission denied for table events_event
+```
+
+Both must fail with a `permission denied` error. If either succeeds, the role has write access — stop, `DROP` anything you created with a properly-privileged role, fix the grants in step 1, and re-verify before using this DSN anywhere.
+
+### 6. Security caveat
+
+Setting `PROD_DATABASE_URL` means production database credentials now live in a local `backendServer/.env` file on a developer machine. Treat that seriously:
+
+- `.env` must stay gitignored — never commit it, never paste its contents into a PR, issue, or chat log.
+- Always use the read-only role from step 1 for this variable, never the prod owner/admin DSN. The entire point is to cap blast radius to reads even if the file leaks.
+- If the machine is lost, compromised, or the role's password is suspected to have leaked, revoke/rotate immediately from the Neon console or via `ALTER ROLE monitor_readonly PASSWORD '<new-password>';`, then update `.env` on any machine still using it.
+- When a role is no longer needed (e.g. a laptop is decommissioned), `DROP ROLE monitor_readonly;` rather than leaving it dangling.


### PR DESCRIPTION
## What this is

The login-independent slices of `arya/broadcast-touchup`, ported cleanly onto `main`. The touchup branch bundled **four suites** on one branch; PRs #25–28 shipped it to prod on 07‑15 and broke `POST /broadcast/verify-code` (403 — JWT never reached Django), which PR #29 reverted. This PR salvages only the parts that are safe for `main` and have **zero** dependency on the unfinished login rework.

## Included

**Suite 27 — Neon autosuspend / query-rate reduction**
- Read-through cache for broadcast access resolution + job-status polling: `broadcast/cache.py`, `signals.py`, `apps.py` `ready()` wiring; write-through from `access.py` / `views.py` / `services.py` / `runner.py` / `worker.py`. `job_detail` (polled every 3s) and `resolve_access` (every authed request) no longer hit Neon on a warm cache. Consumption counts / `max_uses` are deliberately **not** cached — always re-checked live.
- Admin sessions moved to the Redis cache and `CONN_MAX_AGE=0`, so idle Django holds no DB connection and Neon compute can autosuspend.
- `devtools` collections-monitoring dashboard + `docs/dev-db-isolation.md`.

**Broadcast form copy touch-ups**
- Button `"Submit events!"` → `"Populate Forms!"`
- Target status label `"submitted"` → `"filled"`
- Unfilled optional-field hint recolored from muted → accent (warning) color.

## Explicitly excluded (remains on `arya/broadcast-touchup`, unmerged)

The login-gated `verify-code` endpoint, trial-code account binding/persistence (`bind_trial_code`), Better-Auth Redis sessions, the neon-http driver switch, and the standalone auth portal (`theCommonsWeb/(portal)/*`). These are the unfinished rework that caused the outage and are **not** in this PR.

## Verification

Local: `ruff check` / `ruff format --check` / `mypy .` (166 files) ✅ · backend fast tier (84 tests) ✅ · `broadcastWeb` `pnpm build` ✅. The DB-tier tests (`test_access_cache`, `test_job_cache`, devtools tests) couldn't run locally (no Postgres) — **relying on CI** here; they're the same files that passed in CI on the touchup branch against this implementation.

## Notes

- The extracted backend files come from the `baf2979` snapshot, *before* Suite 28 layered trial-persistence onto the same functions, so the caching sits on the original `resolve_access` with no auth coupling.
- Bucket A copy/CSS changes may now exist on both this branch and `arya/broadcast-touchup` — that's expected; the touchup branch is intentionally left as-is for further work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)