### PR TITLE
fix: browser User-Agent on JWKS fetch (Cloudflare 403 broke broadcast JWT auth)

### DIFF
--- a/backendServer/backend/jwt_auth.py
+++ b/backendServer/backend/jwt_auth.py
@@ -12,6 +12,12 @@ logger = logging.getLogger(__name__)
 _JWKS_TTL_SECONDS = 600
 _JWKS_STALE_GRACE_SECONDS = 3600
 
+# Cloudflare (in front of auth.thecommons.town) 403s the default "Python-urllib"
+# User-Agent that PyJWKClient sends. Present a browser-like UA so the JWKS fetch
+# is allowed; without this, every Better Auth JWT fails verification.
+_JWKS_USER_AGENT = "Mozilla/5.0 (compatible; TheCommons/1.0)"
+_JWKS_HEADERS = {"User-Agent": _JWKS_USER_AGENT}
+
 _jwks_cache: dict[str, Any] = {
     "client": None,
     "fetched_at": 0.0,
@@ -36,8 +42,13 @@ def _get_jwks_client() -> PyJWKClient | None:
         return cached
 
     try:
-        requests.get(jwks_url, timeout=3).raise_for_status()
-        client = PyJWKClient(jwks_url, cache_jwk_set=True, lifespan=_JWKS_TTL_SECONDS)
+        requests.get(jwks_url, timeout=3, headers=_JWKS_HEADERS).raise_for_status()
+        client = PyJWKClient(
+            jwks_url,
+            cache_jwk_set=True,
+            lifespan=_JWKS_TTL_SECONDS,
+            headers=_JWKS_HEADERS,
+        )
         _jwks_cache["client"] = client
         _jwks_cache["fetched_at"] = now
         _jwks_cache["stale_after"] = now + _JWKS_TTL_SECONDS + _JWKS_STALE_GRACE_SECONDS


### PR DESCRIPTION
## Root cause
Cloudflare fronting `auth.thecommons.town` returns **403** to the default `Python-urllib` User-Agent that `PyJWKClient` uses to fetch the Better Auth JWKS. Django could never retrieve the signing key, so `verify_better_auth_jwt` returned `None` for every token → every JWT-gated broadcast call 403'd, including **tier-2 access-code redeem**.

The pre-flight `requests.get` health check in `_get_jwks_client` masked it: `requests`' UA is allowed (200), so the client was created — but the client's own `urllib` fetch then 403'd.

### Evidence (from the prod VM)
- Gunicorn logs: `PyJWKClientConnectionError: ... "HTTP Error 403: Forbidden"`
- `urllib` default UA → **403**; `requests` → 200; `urllib` browser UA → 200
- `curl` to the JWKS URL → 200 with a valid Ed25519 key

## Fix
Send a browser-like `User-Agent` on both the pre-flight check and the `PyJWKClient` fetch (PyJWT 2.12.1 supports the `headers=` kwarg). Verified live: `PyJWKClient(headers=...)` now fetches the key set.

## Test
- `broadcast --tag=fast`: 53 pass
- Verified `PyJWKClient` + headers fetches keys against the live Cloudflare-fronted endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)