### PR TITLE
fix: broadcast access UX — expired-code message + wipe form on sign-out

### DIFF
--- a/backendServer/broadcast/access.py
+++ b/backendServer/broadcast/access.py
@@ -31,6 +31,10 @@ class AccessResult:
     uses_remaining: int | None
     client_label: str | None
     code: AccessCode | None = field(default=None)
+    # Why access was denied on a matched-but-dead TRIAL code: "expired" or
+    # "exhausted". None otherwise. Lets callers surface a specific message
+    # instead of a generic "Invalid credentials."
+    reason: str | None = field(default=None)
 
 
 def hash_code(raw: str) -> str:
@@ -55,24 +59,29 @@ def authenticated_email(request) -> str | None:
     return email.lower() if email else None
 
 
-def _trial_liveness(code: AccessCode, draft_id: str | None, now) -> tuple[bool, int | None]:
-    """Live expiry + max_uses check for a TRIAL code. Returns (ok, uses_remaining).
+def _trial_liveness(
+    code: AccessCode, draft_id: str | None, now
+) -> tuple[bool, int | None, str | None]:
+    """Live expiry + max_uses check for a TRIAL code.
+
+    Returns (ok, uses_remaining, reason). `reason` is None when ok, else
+    "expired" or "exhausted" so callers can surface a specific message.
 
     Factored out so it can be called against a cached code row without
     duplicating the expiry/metering logic. Never cached itself — consumption
     counts must always be live (see cache.py docstring).
     """
     if code.expires_at is not None and code.expires_at < now:
-        return False, None
+        return False, None, "expired"
     used = code.uses.count()
     if code.max_uses is None:
-        return True, None
+        return True, None, None
     uses_remaining = max(code.max_uses - used, 0)
     if used >= code.max_uses:
         already_counted = draft_id is not None and code.uses.filter(draft_id=draft_id).exists()
         if not already_counted:
-            return False, uses_remaining
-    return True, uses_remaining
+            return False, uses_remaining, "exhausted"
+    return True, uses_remaining, None
 
 
 def resolve_access(request, draft_id: str | None = None) -> AccessResult:  # noqa: C901  # tiered auth resolution; complexity is inherent
@@ -150,9 +159,9 @@ def resolve_access(request, draft_id: str | None = None) -> AccessResult:  # noq
             matched = AccessCode.objects.filter(id=cached_meta["code_id"]).first()
 
         if matched is not None:
-            ok, uses_remaining = _trial_liveness(matched, draft_id, now)
+            ok, uses_remaining, reason = _trial_liveness(matched, draft_id, now)
             if not ok:
-                return AccessResult(0, None, False, None, None, None)
+                return AccessResult(0, None, False, None, None, None, reason=reason)
 
             label = matched.label
             return AccessResult(

--- a/backendServer/broadcast/tests/test_access_db.py
+++ b/backendServer/broadcast/tests/test_access_db.py
@@ -288,6 +288,30 @@ class AccessInfoEndpointTest(TestCase):
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(resp.json()["detail"], "Invalid credentials.")
 
+    def test_expired_code_returns_403_with_specific_message(self):
+        _make_code(raw="EXPINFO", expires_at=timezone.now() - timedelta(hours=1))
+        resp = self.client.get(
+            "/broadcast/access",
+            HTTP_X_BROADCAST_ACCESS_CODE="EXPINFO",
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(
+            resp.json()["detail"], "This access code has expired — please contact support."
+        )
+
+    def test_exhausted_code_returns_403_with_specific_message(self):
+        code = _make_code(raw="FULLINFO", max_uses=1)
+        AccessCodeUse.objects.create(access_code=code, draft_id="draft-used")
+        resp = self.client.get(
+            "/broadcast/access",
+            HTTP_X_BROADCAST_ACCESS_CODE="FULLINFO",
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(
+            resp.json()["detail"],
+            "This access code has no uses remaining — please contact support.",
+        )
+
     def test_valid_code_returns_200_with_trial_info(self):
         _make_code(raw="INFOCODE", max_uses=3)
         resp = self.client.get(

--- a/backendServer/broadcast/views.py
+++ b/backendServer/broadcast/views.py
@@ -36,6 +36,13 @@ from broadcast.services import (
     submit_real_targets,
 )
 
+# Maps AccessResult.reason (set by resolve_access for a matched-but-dead trial
+# code) to the message shown to the caller. Falls back to a generic message.
+_ACCESS_DENIED_DETAIL = {
+    "expired": "This access code has expired — please contact support.",
+    "exhausted": "This access code has no uses remaining — please contact support.",
+}
+
 
 @ratelimit(key="ip", rate="10/m", method="POST", block=True)
 @api_view(["POST"])
@@ -284,6 +291,7 @@ def access_info(request):
 
     No permission class — open to all. Returns 403 only when credentials
     were supplied but could not be validated (invalid JWT or unknown code).
+    A matched-but-dead trial code gets a specific message via result.reason.
     """
     result = resolve_access(request)
 
@@ -292,7 +300,8 @@ def access_info(request):
     credentials_supplied = auth_header.startswith("Bearer ") or bool(code_header)
 
     if credentials_supplied and result.identity is None:
-        return Response({"detail": "Invalid credentials."}, status=status.HTTP_403_FORBIDDEN)
+        detail = _ACCESS_DENIED_DETAIL.get(result.reason, "Invalid credentials.")
+        return Response({"detail": detail}, status=status.HTTP_403_FORBIDDEN)
 
     return Response(
         {

--- a/broadcastWeb/src/App.tsx
+++ b/broadcastWeb/src/App.tsx
@@ -521,14 +521,17 @@ export default function App() {
     }
   };
 
+  // Signing out wipes the form entirely — clear both persistence scopes and
+  // reload for a guaranteed-clean, stale-data-free mount (same approach as
+  // handleHardReset). try/finally so the reload still fires if signOut rejects.
   const handleSignOut = async () => {
-    await authClient.signOut();
-    setJwt(null);
-    setTier(0);
-    setIsTrial(false);
-    setUsesRemaining(null);
-    setAccessSource(null);
-    setAccessError("");
+    clearDraft();
+    clearSession();
+    try {
+      await authClient.signOut();
+    } finally {
+      window.location.reload();
+    }
   };
 
   // Full hard reset: clears local persistence and the auth session, then

--- a/broadcastWeb/src/App.tsx
+++ b/broadcastWeb/src/App.tsx
@@ -499,7 +499,9 @@ export default function App() {
     }
     try {
       const access = await getAccess({ accessCode });
-      if (access.tier === 0) throw new ApiError(403, "code grants no access");
+      if (access.tier === 0) {
+        throw new ApiError(403, "Access code not recognized. Check the code and try again.");
+      }
       setAccessVerified(true);
       setVerifiedCode(accessCode);
       setAccessSource("code");
@@ -507,9 +509,15 @@ export default function App() {
       setIsTrial(access.is_trial);
       setUsesRemaining(access.uses_remaining);
       setShowCodeEntry(false);
-    } catch {
+    } catch (e) {
       setAccessVerified(false);
-      setAccessError("Access code not recognized. Check the code and try again.");
+      // Surface the backend's specific message (expired/exhausted → contact
+      // support) when present; fall back to a generic not-recognized message.
+      setAccessError(
+        e instanceof ApiError && e.status === 403 && e.message
+          ? e.message
+          : "Access code not recognized. Check the code and try again.",
+      );
     }
   };
 

--- a/broadcastWeb/src/services/__tests__/broadcastApi.fast.test.ts
+++ b/broadcastWeb/src/services/__tests__/broadcastApi.fast.test.ts
@@ -110,12 +110,17 @@ describe("getAccess", () => {
     expect((init.headers as Record<string, string>)["X-Broadcast-Access-Code"]).toBe("CODE");
   });
 
-  it("throws ApiError on 403", async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ detail: "Invalid credentials." }, { ok: false, status: 403 }));
+  it("throws ApiError on 403, surfacing the backend detail", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { detail: "This access code has expired — please contact support." },
+        { ok: false, status: 403 },
+      ),
+    );
 
     await expect(getAccess(JWT_AUTH)).rejects.toMatchObject({
       status: 403,
-      message: expect.stringContaining("Access denied"),
+      message: "This access code has expired — please contact support.",
     });
   });
 

--- a/broadcastWeb/src/services/broadcastApi.ts
+++ b/broadcastWeb/src/services/broadcastApi.ts
@@ -41,7 +41,14 @@ export function authHeaders(auth: ApiAuth): Record<string, string> {
 }
 
 const messageFor = (status: number, body: unknown): string => {
-  if (status === 403) return "Access denied — check your credentials or access code.";
+  // Prefer the backend's own `detail` (e.g. an expired/exhausted access code)
+  // so the specific message reaches the user instead of a generic 403 string.
+  const detail = (body as { detail?: unknown } | null)?.detail;
+  if (status === 403) {
+    return typeof detail === "string"
+      ? detail
+      : "Access denied — check your credentials or access code.";
+  }
   if (status === 400) return `The form has a problem: ${JSON.stringify(body)}`;
   return `Request failed (${status}).`;
 };


### PR DESCRIPTION
Two small broadcast access/auth UX fixes.

## 1. Specific message for expired/exhausted access codes
A valid-but-dead **trial** code previously returned the generic `Invalid credentials.` 403 from `GET /broadcast/access` — indistinguishable from an unknown code.
- **Backend:** `_trial_liveness` returns a `reason` (`"expired"` / `"exhausted"`); `resolve_access` carries it on `AccessResult.reason`; `access_info` maps it to a support-directing message. Unknown code / bad JWT still return `Invalid credentials.`
- **Frontend:** `messageFor` surfaces the backend `detail` on a 403; the code-verify handler shows it instead of its hardcoded fallback.

Messages: expired → "This access code has expired — please contact support."; exhausted → "This access code has no uses remaining — please contact support."

## 2. Wipe the form on sign-out
`handleSignOut` reset only auth state, leaving the draft, preview, selected sites, contact details, and access code in place (and in localStorage). It now clears both persistence scopes and reloads for a guaranteed-clean mount (mirrors `handleHardReset`) — signing out leaves an empty form, no stale data.

## Tests
- Backend `test_access_db`: 50 pass (2 new endpoint tests)
- broadcastWeb: 81 pass, `pnpm build` clean, ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)