### PR TITLE
feat: tier-1 upgrade prompt in AI Autofill section

### DIFF
--- a/broadcastWeb/src/App.tsx
+++ b/broadcastWeb/src/App.tsx
@@ -910,8 +910,13 @@ export default function App() {
           <p className="hint">
             Paste a raw event description, email, or flyer text below and the AI will fill
             the event fields for you.
-            {tier < 2 && <em> Available with Tier 2 access.</em>}
+            {tier === 0 && <em> Available with Tier 2 access.</em>}
           </p>
+          {tier === 1 && (
+            <p className="field-error">
+              Talk to support and upgrade your plan to access this feature.
+            </p>
+          )}
           <textarea
             className="ai-autofill-textarea"
             placeholder="Paste an event description / flyer text / email…"


### PR DESCRIPTION
## What
Tier 1 clients now see a **red** message in the AI Autofill section:

> Talk to support and upgrade your plan to access this feature.

AI Autofill is a tier 2 feature; tier 1 clients are paying customers below that gate, so this gives them an actionable upgrade path (vs the previous subtle grey "Available with Tier 2 access." note).

## Details
- Shown only when `tier === 1`, using the existing `.field-error` red style (`#c0392b`).
- The pre-existing grey "Available with Tier 2 access." note is now scoped to `tier === 0`, so tier 1 sees the single actionable red prompt rather than two overlapping messages. Tier 2 sees neither (feature is live).

## Tests
- broadcastWeb: 81 pass, `pnpm build` type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)