### PR TITLE
fix(events): cover Siler City + Bynum so Chatham events stop being dropped (35.14)

### DIFF
--- a/backendServer/events/management/commands/seed_dev.py
+++ b/backendServer/events/management/commands/seed_dev.py
@@ -12,6 +12,8 @@ TOWNS = [
     ("hillsborough", "Hillsborough"),
     ("durham", "Durham"),
     ("pittsboro", "Pittsboro"),
+    ("siler-city", "Siler City"),
+    ("bynum", "Bynum"),
 ]
 
 TAGS = [

--- a/backendServer/events/migrations/0016_seed_chatham_towns.py
+++ b/backendServer/events/migrations/0016_seed_chatham_towns.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+
+# Chatham County coverage. Pittsboro (the county seat) was already covered by
+# 0004, but Siler City and Bynum were not — so Gemini classified their events
+# into slugs with no `Town` row and `publish_approved_events` dropped them.
+# `chapel-hill` is listed because it exists in prod but was never seeded by a
+# migration; including it here makes a fresh database match prod.
+TOWNS = [
+    ("chapel-hill", "Chapel Hill"),
+    ("siler-city", "Siler City"),
+    ("bynum", "Bynum"),
+]
+
+
+def seed_towns(apps, schema_editor):
+    Town = apps.get_model("events", "Town")
+    for slug, name in TOWNS:
+        Town.objects.get_or_create(slug=slug, defaults={"name": name})
+
+
+def unseed_towns(apps, schema_editor):
+    # Only the two genuinely new towns are reversible. `chapel-hill` predates
+    # this migration in prod, so removing it on rollback would be destructive.
+    # Events point at Town with on_delete=SET_NULL, so this is non-cascading.
+    Town = apps.get_model("events", "Town")
+    Town.objects.filter(slug__in=["siler-city", "bynum"]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("events", "0015_seed_digest_beat"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_towns, unseed_towns),
+    ]

--- a/backendServer/events/tests/test_town_seed_db.py
+++ b/backendServer/events/tests/test_town_seed_db.py
@@ -1,0 +1,25 @@
+"""Guards the Town rows seeded by migrations (events 0004, 0016).
+
+Town coverage is not cosmetic: `publish_approved_events` drops any staged event
+whose Gemini-classified town has no matching `Town` row (ingestion/services.py).
+A migration that removes one of these silently stops publishing that town's
+events, with no error anywhere — which is exactly what happened to Siler City
+and Bynum before 0016.
+"""
+
+from django.test import TestCase, tag
+
+from events.models import Town
+
+
+@tag("db")
+class TownSeedTests(TestCase):
+    def test_covered_towns_seeded(self):
+        expected = {"carrboro", "chapel-hill", "pittsboro", "siler-city", "bynum"}
+        self.assertTrue(expected <= set(Town.objects.values_list("slug", flat=True)))
+
+    def test_chatham_county_towns_have_display_names(self):
+        # The slug is what the pipeline matches on, but the name is what the
+        # reader sees, so a blank/placeholder name would ship to the site.
+        self.assertEqual(Town.objects.get(slug="siler-city").name, "Siler City")
+        self.assertEqual(Town.objects.get(slug="bynum").name, "Bynum")

--- a/backendServer/ingestion/tests/test_services_db.py
+++ b/backendServer/ingestion/tests/test_services_db.py
@@ -15,12 +15,12 @@ class PublishAllApprovedTests(TestCase):
     def setUp(self):
         Town.objects.get_or_create(slug="carrboro", defaults={"name": "Carrboro"})
 
-    def _staged(self, title, status, **kwargs):
+    def _staged(self, title, status, town="Carrboro", **kwargs):
         return StagedEvent.objects.create(
             title=title,
             description="d",
             location_name="Venue",
-            town="Carrboro",
+            town=town,
             start_datetime=START,
             status=status,
             **kwargs,
@@ -89,3 +89,37 @@ class PublishAllApprovedTests(TestCase):
         original.refresh_from_db()
         self.assertEqual(original.status, "published")
         self.assertEqual(dupe.duplicate_of_id, original.id)
+
+    def test_chatham_county_towns_publish(self):
+        """Regression for 35.14. Gemini classifies Chatham County events into
+        "Siler City" / "Bynum"; before events 0016 seeded those Towns, every one
+        of them hit the `no Town matches slug` branch and was skipped — ~26 in a
+        single prod run, including an event titled "Chatham County Parks and
+        Recreation Summer Camp". Pittsboro, the county seat, was already covered.
+        """
+        self._staged("Growers & Makers Market", "approved", town="Siler City")
+        self._staged("Bynum Front Porch Music", "approved", town="Bynum")
+
+        result = publish_all_approved()
+
+        self.assertEqual(result["published"], 2)
+        self.assertEqual(
+            dict(Event.objects.values_list("title", "town__slug")),
+            {"Growers & Makers Market": "siler-city", "Bynum Front Porch Music": "bynum"},
+        )
+
+    def test_unmatched_town_is_skipped_but_retried(self):
+        """A town outside coverage (Apex is not in the service area) is still
+        skipped — but the row keeps published_event=None, so the terminal
+        approved->published sweep leaves it alone and the next run retries it.
+        That is why adding a Town row backfills previously-dropped events with
+        no separate migration.
+        """
+        self._staged("Somewhere Else", "approved", town="Apex")
+
+        result = publish_all_approved()
+
+        self.assertEqual(result["published"], 0)
+        self.assertEqual(result["removed"], 0)
+        self.assertFalse(Event.objects.exists())
+        self.assertEqual(StagedEvent.objects.get(title="Somewhere Else").status, "approved")

--- a/notion-sync/STATE.md
+++ b/notion-sync/STATE.md
@@ -26,11 +26,11 @@ per-ticket status lives on each ticket subpage (see OUTBOX preamble).
 | 25 | Broadcast dispatch on Celery (kill the 3s Neon poll) | Needs QA | 25.1–25.9 | _(pending)_ |
 | 29 | Standalone auth portal (auth.thecommons.town) | Needs QA | 29.1–29.7 | _(pending)_ |
 | 30 | Broadcast auth + access-code debugging (JWT bridge, sign-in 401, tier-0, request reduction, hard reset) | Needs QA | 30.1–30.8 | _(pending)_ |
-| 31 | Broadcast client-feedback fixes (organizer/contact fields, AI autofill, TW tags + image uploads, ABC11 identity + date/time) | Needs QA | 31.1–31.11 | _(pending)_ |
-| 32 | Ingestion observability devtool (run history, live probe, funnel metrics, health flags) | Needs QA | 32.1–32.8 | _(pending)_ |
-| 33 | Ingestion monitor diagnostics correctness (health levels, zero legibility, GRANT detection) | Needs QA | 33.1–33.5 | _(pending)_ |
-| 34 | Ingestion pipeline resilience (dedupe corpus, standardizer fallback, direct-submission delivery) | Needs QA | 34.1–34.5 | _(pending)_ |
-| 35 | Prod scheduler outage (snap-uv user-slice teardown) + monitor correctness | Staged for Prod | 35.1–35.11, 35.13, 35.14 (35.12 merged into 35.8) | _(pending)_ |
+| 31 | Broadcast client-feedback fixes (organizer/contact fields, AI autofill, TW tags + image uploads, ABC11 identity + date/time) | In Prod | 31.1–31.11 | _(pending)_ |
+| 32 | Ingestion observability devtool (run history, live probe, funnel metrics, health flags) | In Prod | 32.1–32.8 | _(pending)_ |
+| 33 | Ingestion monitor diagnostics correctness (health levels, zero legibility, GRANT detection) | In Prod | 33.1–33.5 | _(pending)_ |
+| 34 | Ingestion pipeline resilience (dedupe corpus, standardizer fallback, direct-submission delivery) | In Prod | 34.1–34.5 | _(pending)_ |
+| 35 | Prod scheduler outage (snap-uv user-slice teardown) + monitor correctness | In Prod | 35.1–35.11, 35.13, 35.14 (35.12 merged into 35.8) | _(pending)_ |
 
 <!--
 Columns (left→right): Idea · Open · In Progress · Needs QA · Staged for Prod · In Prod


### PR DESCRIPTION
## Why

`publish_approved_events` skips any staged event whose Gemini-classified town has no matching `Town` row, logging a warning and continuing (`ingestion/services.py:62-70`). `events.Town` held only `carrboro`, `chapel-hill` and `pittsboro`, so **every Siler City and Bynum event was discarded** — ~26 in a single prod run on 2026-07-29, including one titled *"Chatham County Parks and Recreation Summer Camp - Week 5"*.

Both towns are in **Chatham County**, whose seat (Pittsboro) was already covered. This was a coverage gap inside the paper's own county, not out-of-area filtering working correctly. Apex and Durham are defensibly out of scope and still drop.

It was also invisible: affected sources read `raw > 0, published = 0` with no reason given anywhere in the monitor.

## What changed

- **`events/0016_seed_chatham_towns.py`** seeds `siler-city` and `bynum` idempotently.
  It also seeds `chapel-hill`, which **exists in prod but was never in any migration** — `0004` seeded only carrboro + pittsboro — so a fresh database now matches prod instead of silently missing a covered town.
  The reverse removes only the two new towns; dropping `chapel-hill` on rollback would be destructive.
- **`seed_dev`** town list updated to match.

## No backfill migration is needed

A dropped row keeps `published_event=None`, and the terminal approved→published sweep (`services.py:103`) only touches rows that actually got an Event. So dropped rows stay `approved` and the **next publish run picks them up automatically** — the ~26 already-dropped Chatham events backfill on their own once this deploys.

That behaviour is now pinned by a test rather than left as a happy assumption.

## Tests

- `events/tests/test_town_seed_db.py` — guards the seeded rows. A future migration removing one would otherwise silently stop publishing that town, with no error anywhere.
- `test_services_db.py` — both directions: Chatham towns publish, and out-of-scope Apex is still skipped **while remaining retryable**.

`_staged()` gained a `town` parameter (it hardcoded `"Carrboro"`, so passing `town=` collided with `**kwargs`).

## Still open

The monitor cannot explain this class of hole. A "dropped: unmatched town" bucket needs its own ticket — deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)