### PR TITLE
fix(healthcheck): give broadcast-orphan-recovery a staleness window

### DIFF
--- a/backendServer/events/management/commands/healthcheck.py
+++ b/backendServer/events/management/commands/healthcheck.py
@@ -37,6 +37,9 @@ DEFAULT_STALENESS_HOURS = {
     "ingest-events-daily": 25,
     "scrape-sources-daily": 25,
     "weekly-digest-sunday": 24 * 8,  # ~8 days
+    # Runs `0 */6 * * *`; one interval plus an hour of grace, matching the
+    # +1h pattern the daily windows use.
+    "broadcast-orphan-recovery": 7,
 }
 
 

--- a/backendServer/events/tests/test_healthcheck_freshness.py
+++ b/backendServer/events/tests/test_healthcheck_freshness.py
@@ -46,6 +46,27 @@ class TaskFreshnessUnitTests(unittest.TestCase):
         self.assertIn("scrape-sources-daily", DEFAULT_STALENESS_HOURS)
         self.assertEqual(DEFAULT_STALENESS_HOURS["scrape-sources-daily"], 25)
 
+    def test_broadcast_orphan_recovery_has_a_configured_window(self):
+        # Found by the first real healthcheck run on prod (2026-07-29): the task
+        # is seeded by broadcast/0009 but had no window, so it reported WARN
+        # "no staleness window configured" — the exact ride-along case the
+        # DEFAULT_STALENESS_HOURS comment warns about. Schedule is `0 */6 * * *`.
+        self.assertEqual(DEFAULT_STALENESS_HOURS["broadcast-orphan-recovery"], 7)
+
+    def test_orphan_recovery_one_missed_interval_still_ok(self):
+        # 6h schedule + 1h grace: a run that merely landed late must not FAIL.
+        task = _fake_task("broadcast-orphan-recovery", self.now - timedelta(hours=6, minutes=30))
+        status, _, _ = self.cmd._task_freshness(task, "beat:broadcast-orphan-recovery", self.now)
+        self.assertEqual(status, OK)
+
+    def test_orphan_recovery_two_missed_intervals_fails(self):
+        task = _fake_task("broadcast-orphan-recovery", self.now - timedelta(hours=13))
+        status, _, detail = self.cmd._task_freshness(
+            task, "beat:broadcast-orphan-recovery", self.now
+        )
+        self.assertEqual(status, FAIL)
+        self.assertIn("STALE", detail)
+
     def test_configured_task_never_run_fails(self):
         task = _fake_task("scrape-sources-daily", None)
         status, _, detail = self.cmd._task_freshness(task, "beat:scrape-sources-daily", self.now)


### PR DESCRIPTION
Found by **running the healthcheck on prod for the first time**, immediately after installing the systemd timer (suite 35, step 5).

## The finding

```
! beat:broadcast-orphan-recovery   no staleness window configured — add to DEFAULT_STALENESS_HOURS
✓ beat:ingest-events-daily         last run 9.7h ago
✓ beat:scrape-sources-daily        last run 10.2h ago
✗ beat:weekly-digest-sunday        STALE — last run 211.1h ago (> 192h window)
```

`broadcast-orphan-recovery` is seeded into the beat schedule by `broadcast/0009_seed_orphan_recovery_beat.py` but was never added to `DEFAULT_STALENESS_HOURS` — so its staleness could never fail. That is precisely the ride-along case the dict's own comment warns about:

> every task the pipeline depends on belongs here, or its staleness silently passes forever (2026-07-21 scheduler outage)

Given the outage this suite exists to fix was *a scheduled task quietly not running*, a scheduled task that structurally cannot report staleness is worth closing.

## The change

Schedule is `0 */6 * * *`, so the window is **6h + 1h grace = 7**, matching the `+1h` pattern the daily entries already use (`24 → 25`).

**Note:** `DEFAULT_STALENESS_HOURS` doubles as the must-exist set in `_check_periodic_tasks`, so adding the key also makes a *missing* schedule entry a FAIL. That's safe — the task is created by a migration, so any migrated database has it. I verified this rather than assuming it.

## Tests

Boundaries in both directions, so a future retune can't silently widen the window into uselessness:
- one late interval (6h30m) → still `OK`
- two missed intervals (13h) → `FAIL`

## Not addressed here

The `weekly-digest-sunday` FAIL above is real and separate: beat was dead through Sunday 2026-07-26, so **that week's digest was never sent**. It is not a healthcheck bug — the check is correctly reporting missed work. Next run is Sunday 2026-08-02, which will clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)